### PR TITLE
Fix non-CLASSIC build after "Fix UBRS opening door in CLASSIC"

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
@@ -109,11 +109,14 @@ struct is_blackrock_spire : public InstanceScript
             m_uiFlamewreathWaveCount(0),
             m_uiStadiumEventTimer(0),
             m_uiStadiumWaves(0),
-            m_uiStadiumMobsAlive(0),
 #if defined (CLASSIC)
+            m_uiStadiumMobsAlive(0),
+
             m_uiDragonspineDoorTimer(0),
             m_uiDragonspineGoCount(0),
             m_bUpperDoorOpened(false)
+#else
+            m_uiStadiumMobsAlive(0)
 #endif
         {
             Initialize();


### PR DESCRIPTION
Commit "Fix UBRS opening door in CLASSIC" broke non-CLASSIC build (e.g. MaNGOS-Two):

[ 54%] Building CXX object src/modules/SD3/CMakeFiles/mangosscript.dir/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp.o
/service/server/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp: In constructor 'is_blackrock_spire::instance_blackrock_spire::instance_blackrock_spire(Map*)':
/service/server/src/modules/SD3/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp:118:9: error: expected identifier before '{' token
         {
         ^

This happened because of removed #else macro on line 117 - there must be no "," before "{".
This commit adds #else again.
