### PR TITLE
Temp Revert "BRD Arena Fix" - Causes build failure

### DIFF
--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -237,7 +237,7 @@ struct at_ring_of_law : public AreaTriggerScript
 
             pPlayer->SummonCreature(NPC_GRIMSTONE, aSpawnPositions[POS_GRIMSTONE][0], aSpawnPositions[POS_GRIMSTONE][1], aSpawnPositions[POS_GRIMSTONE][2], aSpawnPositions[POS_GRIMSTONE][3], TEMPSUMMON_DEAD_DESPAWN, 0);
             pInstance->SetData(TYPE_SIGNAL, pAt->id);
-            pInstance->SetArenaCenterCoords(pAt->x, pAt->y, pAt->z);
+            //pInstance->SetArenaCenterCoords(pAt->x, pAt->y, pAt->z);
 
             return false;
         }


### PR DESCRIPTION
Reverts mangos/ScriptDev3#45
Admin revert due to build failure. //I'm not a programmer but reverting as none are free to fix this right at this moment. I will notify @billy1arm to look at why this failed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/scriptdev3/46)

<!-- Reviewable:end -->
