### PR TITLE
Quest Fix: The Attack!

### DIFF
--- a/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -68,8 +68,6 @@ struct npc_tyrion : public CreatureScript
         if (pQuest->GetQuestId() == QUEST_THE_ATTACK)
         {
             pCreature->GetMap()->MonsterYellToMap(pCreature->GetObjectGuid(), -1000824, LANG_UNIVERSAL, pPlayer);
-            pCreature->SetFactionTemporary(FACTION_ENEMY, TEMPFACTION_RESTORE_RESPAWN | TEMPFACTION_RESTORE_COMBAT_STOP);
-            pCreature->AI()->AttackStart(pPlayer);
             return true;
         }
 


### PR DESCRIPTION
removing them lines will now operate the script correctly, why was we setting his faction to enemy and also making him attack the player?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/scriptdev3/65)
<!-- Reviewable:end -->
