### PR TITLE
Add GameObjectAI Implementation + Dire Maul Fixes

### DIFF
--- a/include/precompiled.h
+++ b/include/precompiled.h
@@ -32,6 +32,7 @@
 #include "Creature.h"
 #include "CreatureAI.h"
 #include "GameObject.h"
+#include "GameObjectAI.h"
 #include "sc_creature.h"
 #include "sc_gossip.h"
 #include "sc_grid_searchers.h"

--- a/scripts/kalimdor/dire_maul/dire_maul.h
+++ b/scripts/kalimdor/dire_maul/dire_maul.h
@@ -101,7 +101,10 @@ enum
     SAY_FREE_IMMOLTHAR          = -1429000,
     SAY_KILL_IMMOLTHAR          = -1429001,
     SAY_IRONBARK_REDEEM         = -1429002,
-    SAY_CHORUSH_KING_DEAD    = -1429003,
+    SAY_CHORUSH_KING_DEAD       = -1429003,
+    SAY_SLIPKIK_TRAP            = -1429004,
+
+    SPELL_ICE_BLOCK             = 22856,
 
     FACTION_HOSTILE             = 14,
     FACTION_FRIENDLY        = 35,

--- a/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
+++ b/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
@@ -35,6 +35,7 @@
 
 #include "precompiled.h"
 #include "dire_maul.h"
+#include "GameObjectAI.h"
 
 struct is_dire_maul : public InstanceScript
 {
@@ -100,9 +101,18 @@ struct is_dire_maul : public InstanceScript
                 return;
 
                 // North
+            case NPC_CAPTAIN_KROMCRUSH:
+            {
+                // Reset Npc flag to None
+                pCreature->SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
+                break;
+            }
             case NPC_CHORUSH:
             case NPC_KING_GORDOK:
             case NPC_MIZZLE_THE_CRAFTY:
+            case NPC_GUARD_SLIPKIK:
+            case NPC_GUARD_MOLDAR:
+            case NPC_GUARD_FENGUS:
                 break;
 
             default:
@@ -297,20 +307,7 @@ struct is_dire_maul : public InstanceScript
             case TYPE_KING_GORDOK:
                 m_auiEncounter[uiType] = uiData;
                 if (uiData == DONE)
-                {
-                    // change faction to certian ogres
-                    if (Creature* pOgre = GetSingleCreatureFromStorage(NPC_CAPTAIN_KROMCRUSH))
-                    {
-                        if (pOgre->IsAlive())
-                        {
-                            pOgre->SetFactionTemporary(FACTION_FRIENDLY, TEMPFACTION_RESTORE_RESPAWN);
-
-                            // only evade if required
-                            if (pOgre->getVictim())
-                                pOgre->AI()->EnterEvadeMode();
-                        }
-                    }
-
+                {                   
                     if (Creature* pOgre = GetSingleCreatureFromStorage(NPC_CHORUSH))
                     {
                         // Chorush evades and yells on king death (if alive)
@@ -320,6 +317,11 @@ struct is_dire_maul : public InstanceScript
                             pOgre->SetFactionTemporary(FACTION_FRIENDLY, TEMPFACTION_RESTORE_RESPAWN);
                             pOgre->AI()->EnterEvadeMode();
                         }
+                        else
+                        {
+                            // Well if you kill chorush, no tribute ! He is the one who summons Mizzle the Crafty
+                            break;
+                        }
 
                         // start WP movement for Mizzle; event handled by movement and gossip dbscripts
                         if (Creature* pMizzle = pOgre->SummonCreature(NPC_MIZZLE_THE_CRAFTY, afMizzleSpawnLoc[0], afMizzleSpawnLoc[1], afMizzleSpawnLoc[2], afMizzleSpawnLoc[3], TEMPSUMMON_DEAD_DESPAWN, 0, true))
@@ -327,7 +329,57 @@ struct is_dire_maul : public InstanceScript
                             pMizzle->SetWalk(false);
                             pMizzle->GetMotionMaster()->MoveWaypoint();
                         }
+
+                        // change faction to certain ogres
+                        std::vector<uint32> specificOgresThatMustBecomeFriendly;
+                        specificOgresThatMustBecomeFriendly.push_back(NPC_GUARD_MOLDAR);
+                        specificOgresThatMustBecomeFriendly.push_back(NPC_GUARD_SLIPKIK);
+                        specificOgresThatMustBecomeFriendly.push_back(NPC_CAPTAIN_KROMCRUSH);
+                        specificOgresThatMustBecomeFriendly.push_back(NPC_GUARD_FENGUS);
+
+                        for (std::vector<uint32>::iterator ogreItr = specificOgresThatMustBecomeFriendly.begin(); ogreItr != specificOgresThatMustBecomeFriendly.end(); ++ogreItr)
+                        {
+                            if (Creature* pOgre = GetSingleCreatureFromStorage(*ogreItr))
+                            {
+                                if (pOgre->IsAlive())
+                                {
+                                    pOgre->SetFactionTemporary(FACTION_FRIENDLY, TEMPFACTION_RESTORE_RESPAWN);
+
+                                    bool enterEvadeMode = true;
+
+                                    switch (*ogreItr)
+                                    {
+                                        case NPC_GUARD_SLIPKIK:
+                                        {
+                                            // Risk of interrupting "Ice Block" spell if is affected by trap
+                                            if (pOgre->HasAura(SPELL_ICE_BLOCK))
+                                            {
+                                                enterEvadeMode = false;
+                                            }
+                                        }
+                                        case NPC_CAPTAIN_KROMCRUSH:
+                                        {
+                                            // Must reactive NPC flags for komcrush
+                                            pOgre->SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP | UNIT_NPC_FLAG_QUESTGIVER);
+                                            break;
+                                        }
+                                        default:
+                                        {
+                                            break;
+                                        }
+                                    }
+
+                                    // only evade if required
+                                    if (enterEvadeMode && pOgre->getVictim())
+                                    {
+                                        pOgre->AI()->EnterEvadeMode();
+                                    }
+                                }
+                            }
+                        }
+
                     }
+
                 }
                 break;
             case TYPE_MOLDAR:
@@ -618,9 +670,39 @@ struct is_dire_maul : public InstanceScript
     }
 };
 
+struct go_fixed_trap : public GameObjectScript
+{
+    go_fixed_trap() : GameObjectScript("go_fixed_trap")
+    {
+        sLog.outString("go_fixed_trap:: Constructor Called");
+    }
+
+    bool OnUse(Unit* p, GameObject* pGo) override
+    {
+
+        Creature* slipkik = (Creature*)p;
+        slipkik->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
+        DoScriptText(SAY_SLIPKIK_TRAP, slipkik);
+        if (pGo->GetGOInfo()->trap.charges > 0)
+        {
+            pGo->AddUse();
+        }
+
+        pGo->SetLootState(GO_JUST_DEACTIVATED);    // Despawn the trap
+        sLog.outString("go_fixed_trap:: Used by %s", p->GetName());
+
+        return true;
+    }
+
+};
+
+
 void AddSC_instance_dire_maul()
 {
     Script* s;
     s = new is_dire_maul();
+    s->RegisterSelf();
+
+    s = new go_fixed_trap();
     s->RegisterSelf();
 }

--- a/scripts/world/go_scripts.cpp
+++ b/scripts/world/go_scripts.cpp
@@ -54,6 +54,7 @@
  */
 
 #include "precompiled.h"
+#include "GameObjectAI.h"
 
 /*######
 ## go_barov_journal
@@ -356,7 +357,12 @@ struct go_table_theka : public GameObjectScript
         return true;
     }
 };
+
+
+// go_fixed_trap
+
 #endif
+
 
 #if defined (WOTLK) || defined (CATA) || defined(MISTS)
 /*######
@@ -445,6 +451,7 @@ void AddSC_go_scripts()
 #if defined (CLASSIC) || defined (TBC)
     s = new go_table_theka();
     s->RegisterSelf();
+
 #endif
 
 #if defined (TBC) || defined (WOTLK) || defined (CATA) || defined(MISTS)

--- a/system/ScriptDevMgr.cpp
+++ b/system/ScriptDevMgr.cpp
@@ -403,6 +403,18 @@ bool SD3::GOUse(Player* pPlayer, GameObject* pGo)
     return pTempScript->ToGameObjectScript()->OnUse(pPlayer, pGo);
 }
 
+bool SD3::GOUse(Unit* pUnit, GameObject* pGo)
+{
+    Script* pTempScript = m_scripts[pGo->GetScriptId()];
+
+    if (!pTempScript || !pTempScript->ToGameObjectScript())
+    {
+        return false;
+    }
+
+    return pTempScript->ToGameObjectScript()->OnUse(pUnit, pGo);
+}
+
 bool SD3::GOQuestAccept(Player* pPlayer, GameObject* pGo, const Quest* pQuest)
 {
     Script* pTempScript = m_scripts[pGo->GetScriptId()];
@@ -484,6 +496,20 @@ CreatureAI* SD3::GetCreatureAI(Creature* pCreature)
         ai->Reset();
 
     return ai;
+}
+
+GameObjectAI* SD3::GetGameObjectAI(GameObject* pGo)
+{
+    Script* pTempScript = m_scripts[pGo->GetScriptId()];
+
+    if (!pTempScript || !pTempScript->ToGameObjectScript())
+    { 
+        return nullptr;
+    }
+
+    GameObjectAI * goAI = pTempScript->ToGameObjectScript()->GetAI(pGo);
+    
+    return goAI;
 }
 
 bool SD3::ItemUse(Player* pPlayer, Item* pItem, SpellCastTargets const& targets)

--- a/system/ScriptDevMgr.h
+++ b/system/ScriptDevMgr.h
@@ -39,6 +39,7 @@ class InstanceData;
 class Quest;
 class Item;
 class GameObject;
+class GameObjectAI;
 class SpellCastTargets;
 class Map;
 class Unit;
@@ -58,6 +59,7 @@ public:
     static char const* GetScriptLibraryVersion();
 
     static CreatureAI* GetCreatureAI(Creature* pCreature);
+    static GameObjectAI* GetGameObjectAI(GameObject* pGo);
     static InstanceData* CreateInstanceData(Map* pMap);
 
     static bool GossipHello(Player*, Creature*);
@@ -74,6 +76,7 @@ public:
     static uint32 GetNPCDialogStatus(Player*, Creature*);
     static uint32 GetGODialogStatus(Player*, GameObject*);
     static bool GOUse(Player*, GameObject*);
+    static bool GOUse(Unit*, GameObject*);
     static bool ItemUse(Player*, Item*, SpellCastTargets const&);
     static bool ItemEquip(Player*, Item*, bool);    //new TODO
     static bool ItemDelete(Player*, Item*);         //new TODO
@@ -163,6 +166,8 @@ struct Script
     AuraScript* ToAuraScript() { return Type == SCRIPTED_AURASPELL && IsValid() ? (AuraScript*)this : nullptr; }
     ConditionScript* ToConditionScript() { return Type == SCRIPTED_CONDITION && IsValid() ? (ConditionScript*)this : nullptr; }
     AchievementScript* ToAchievementScript() { return Type == SCRIPTED_ACHIEVEMENT && IsValid() ? (AchievementScript*)this : nullptr; }
+    
+   
 };
 
 struct CreatureScript : public Script
@@ -193,6 +198,9 @@ struct GameObjectScript : public Script
     virtual bool OnQuestAccept(Player*, GameObject*, Quest const*) { return false; }
     virtual bool OnQuestRewarded(Player*, GameObject*, Quest const*) { return false; }
     virtual bool OnUse(Player*, GameObject*) { return false; }
+    virtual bool OnUse(Unit*, GameObject*) { return false; }
+
+    virtual GameObjectAI* GetAI(GameObject*) { return nullptr; }
 };
 
 struct ItemScript : public Script


### PR DESCRIPTION
- Now GameObjectAI can be used in SD3 scripts.
- Dire Maul : "fixed trap" works correctly and events related to npc giving buffs in tribute mode are fixed too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/scriptdev3/72)
<!-- Reviewable:end -->
