### PR TITLE
Replaced SIZEFMTD macro with "%zu" format parameter

### DIFF
--- a/base/escort_ai.cpp
+++ b/base/escort_ai.cpp
@@ -632,7 +632,7 @@ void npc_escortAI::Start(bool bRun, const Player* pPlayer, const Quest* pQuest, 
     // disable npcflags
     m_creature->SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
 
-    debug_log("SD3: EscortAI started with " SIZEFMTD " waypoints. Run = %d, PlayerGuid = %s", WaypointList.size(), m_bIsRunning, m_playerGuid.GetString().c_str());
+    debug_log("SD3: EscortAI started with %zu waypoints. Run = %d, PlayerGuid = %s", WaypointList.size(), m_bIsRunning, m_playerGuid.GetString().c_str());
 
     CurrentWP = WaypointList.begin();
 


### PR DESCRIPTION
In this pull request i'm replacing SIZEFMTD macro with %zu format since this parameter is in C standart and most current compilers supports this keyword.

This change will not change or effect any of current code behavior but it would reduce non necessary custom macros usage.
"%zu" keyword is mainly used in text formating to print size_t values

Reference

https://cplusplus.com/articles/iz3hAqkS/

Tests performed
Changes were tested without any additional modules enabled
Changes were tested in windows 10 system, compiled with MSVC 2022 64bit, MySQL 8.0.37, openssl 3.3.0

How to test this pr:
simply compile core, this technically can be tested during mangosd startup since %zu was mainly used in data load related operations

Related to https://github.com/mangoszero/server/pull/196

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/88)
<!-- Reviewable:end -->
