### PR TITLE
Add gendered Sassy dialogue for Megs in Marketing

### DIFF
--- a/scripts/maelstrom/kezan.cpp
+++ b/scripts/maelstrom/kezan.cpp
@@ -36,9 +36,14 @@ EndContentData */
 
 enum
 {
-    QUEST_MEGS_IN_MARKETING = 28349,
-    SAY_SASSY_PROMOTION_MALE   = -1999942,
-    SAY_SASSY_PROMOTION_FEMALE = -1999943,
+    QUEST_MEGS_IN_MARKETING                 = 28349,
+    SAY_SASSY_PROMOTION_MALE                = -1999942,
+    SAY_SASSY_PROMOTION_FEMALE              = -1999943,
+    QUEST_GOOD_HELP_IS_HARD_TO_FIND         = 14069,
+    NPC_DEFIANT_TROLL                       = 34830,
+    SPELL_GOBLIN_ALL_IN_1_DER_BELT_SHOCKER  = 66306,
+    MAX_TROLLS_TO_ADJUST                    = 8,
+    DEFIANT_TROLL_DESPAWN_DELAY             = 2000,
 };
 
 struct npc_sassy_hardwrench_kezan : public CreatureScript
@@ -53,11 +58,6 @@ struct npc_sassy_hardwrench_kezan : public CreatureScript
         }
 
         DoScriptText(pPlayer->getGender() == GENDER_FEMALE ? SAY_SASSY_PROMOTION_FEMALE : SAY_SASSY_PROMOTION_MALE, pCreature, pPlayer);
-    QUEST_GOOD_HELP_IS_HARD_TO_FIND         = 14069,
-    NPC_DEFIANT_TROLL                       = 34830,
-    SPELL_GOBLIN_ALL_IN_1_DER_BELT_SHOCKER = 66306,
-    MAX_TROLLS_TO_ADJUST                    = 8,
-    DEFIANT_TROLL_DESPAWN_DELAY             = 2000,
 };
 
 static const char* const aDefiantTrollTexts[] =

--- a/scripts/maelstrom/kezan.cpp
+++ b/scripts/maelstrom/kezan.cpp
@@ -24,6 +24,7 @@ SDCategory: Kezan
 EndScriptData */
 
 /* ContentData
+npc_sassy_hardwrench_kezan
 EndContentData */
 
 #include "precompiled.h"
@@ -32,6 +33,33 @@ EndContentData */
 #
 ######*/
 
+enum
+{
+    QUEST_MEGS_IN_MARKETING = 28349,
+    SAY_SASSY_PROMOTION_MALE   = -1999942,
+    SAY_SASSY_PROMOTION_FEMALE = -1999943,
+};
+
+struct npc_sassy_hardwrench_kezan : public CreatureScript
+{
+    npc_sassy_hardwrench_kezan() : CreatureScript("npc_sassy_hardwrench_kezan") {}
+
+    bool OnQuestAccept(Player* pPlayer, Creature* pCreature, Quest const* pQuest) override
+    {
+        if (!pPlayer || !pCreature || !pQuest || pQuest->GetQuestId() != QUEST_MEGS_IN_MARKETING)
+        {
+            return false;
+        }
+
+        DoScriptText(pPlayer->getGender() == GENDER_FEMALE ? SAY_SASSY_PROMOTION_FEMALE : SAY_SASSY_PROMOTION_MALE, pCreature, pPlayer);
+        return true;
+    }
+};
+
 void AddSC_kezan()
 {
+    Script* s;
+
+    s = new npc_sassy_hardwrench_kezan();
+    s->RegisterSelf();
 }


### PR DESCRIPTION
Adds a small Kezan SD3 QuestAccept hook for Sassy Hardwrench so quest 28349 plays the correct male/female dialogue variant on accept.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/93)
<!-- Reviewable:end -->
