### PR TITLE
Add Ironforge guard emote response script

### DIFF
--- a/base/guard_ai.cpp
+++ b/base/guard_ai.cpp
@@ -299,6 +299,7 @@ void guardAI::DoReplyToTextEmote(uint32 uiTextEmote)
             break;
         case TEXTEMOTE_RUDE:
         case TEXTEMOTE_CHICKEN:
+        case TEXTEMOTE_RASP:
             m_creature->HandleEmote(EMOTE_ONESHOT_POINT);  // Respond with a point
             break;
     }
@@ -335,5 +336,44 @@ void guardAI_stormwind::ReceiveEmote(Player* pPlayer, uint32 uiTextEmote)
     if (pPlayer->GetTeam() == ALLIANCE)
     {
         DoReplyToTextEmote(uiTextEmote);  // Respond to the emote if the player is Alliance
+    }
+}
+
+/**
+ * @brief Handles emotes received by Ironforge guards.
+ *
+ * This method is called when an Ironforge guard receives an emote from a player.
+ * If the player is a member of the Alliance, the guard will respond to the emote.
+ *
+ * @param pPlayer Pointer to the player sending the emote.
+ * @param uiTextEmote The text emote ID.
+ */
+void guardAI_ironforge::ReceiveEmote(Player* pPlayer, uint32 uiTextEmote)
+{
+    if (pPlayer->GetTeam() == ALLIANCE)
+    {
+        // Respond to the emote if the player is Alliance
+        DoReplyToTextEmote(uiTextEmote);
+
+        switch (uiTextEmote)
+        {
+            case TEXTEMOTE_WAVE:
+                DoScriptText(SAY_IRONFORGE_WAVE, m_creature, pPlayer);
+                break;
+            case TEXTEMOTE_SALUTE:
+                DoScriptText(SAY_IRONFORGE_SALUTE, m_creature, pPlayer);
+                break;
+            case TEXTEMOTE_KISS:
+                DoScriptText(SAY_IRONFORGE_KISS, m_creature, pPlayer);
+                break;
+            case TEXTEMOTE_SHY:
+                DoScriptText(SAY_IRONFORGE_SHY, m_creature, pPlayer);
+                break;
+            case TEXTEMOTE_RUDE:
+            case TEXTEMOTE_CHICKEN:
+            case TEXTEMOTE_RASP:
+                DoScriptText(SAY_IRONFORGE_RUDE, m_creature, pPlayer);
+                break;
+        }
     }
 }

--- a/base/guard_ai.h
+++ b/base/guard_ai.h
@@ -116,6 +116,16 @@ struct guardAI_orgrimmar : public guardAI
     void ReceiveEmote(Player* pPlayer, uint32 uiTextEmote) override;
 };
 
+/// Ironforge Guard scripted text entries
+enum
+{
+    SAY_IRONFORGE_WAVE   = -1001000,
+    SAY_IRONFORGE_SALUTE = -1001001,
+    SAY_IRONFORGE_KISS   = -1001002,
+    SAY_IRONFORGE_SHY    = -1001003,
+    SAY_IRONFORGE_RUDE   = -1001004,
+};
+
 /**
  * @class guardAI_stormwind
  * @brief AI for Stormwind guards.
@@ -128,6 +138,27 @@ struct guardAI_stormwind : public guardAI
      * @param pCreature Pointer to the creature this AI is associated with.
      */
     guardAI_stormwind(Creature* pCreature) : guardAI(pCreature) {}
+
+    /**
+     * @brief Called when the guard receives an emote from a player.
+     * @param pPlayer Pointer to the player sending the emote.
+     * @param uiTextEmote The text emote ID.
+     */
+    void ReceiveEmote(Player* pPlayer, uint32 uiTextEmote) override;
+};
+
+/**
+ * @class guardAI_ironforge
+ * @brief AI for Ironforge guards.
+ */
+struct guardAI_ironforge : public guardAI
+{
+
+    /**
+     * @brief Constructor for guardAI_ironforge.
+     * @param pCreature Pointer to the creature this AI is associated with.
+     */
+    guardAI_ironforge(Creature* pCreature) : guardAI(pCreature) {}
 
     /**
      * @brief Called when the guard receives an emote from a player.

--- a/scripts/world/guards.cpp
+++ b/scripts/world/guards.cpp
@@ -91,6 +91,16 @@ struct guard_stormwind : public CreatureScript
     }
 };
 
+struct guard_ironforge : public CreatureScript
+{
+    guard_ironforge() : CreatureScript("guard_ironforge") {}
+
+    CreatureAI* GetAI(Creature* pCreature) override
+    {
+        return new guardAI_ironforge(pCreature);
+    }
+};
+
 // common AI Part
 struct guard_shattrath_asAI : public guardAI
 {
@@ -198,6 +208,8 @@ void AddSC_guards()
     s = new guard_orgrimmar();
     s->RegisterSelf();
     s = new guard_stormwind();
+    s->RegisterSelf();
+    s = new guard_ironforge();
     s->RegisterSelf();
 
 #if defined (TBC) || defined (WOTLK) || defined (CATA) || defined(MISTS)


### PR DESCRIPTION
## Summary

Adds an Ironforge-specific guard script so Ironforge Guards respond to targeted Alliance player emotes, matching observed retail/classic behavior.

This intentionally does not enable the behavior for all generic city guards. Ironforge Guard entry `5595` is handled by a dedicated `guard_ironforge` script so other guards bound to `guard_generic` remain unchanged.

## Changes

- Added `guardAI_ironforge`, inheriting from `guardAI`.
- Added `ReceiveEmote` handling for Ironforge Guards.
- Reused the existing guard emote response helper path.
- Added `TEXTEMOTE_RASP` handling to `DoReplyToTextEmote`, mapped with the other mocking/taunting emotes.
- Added and registered the `guard_ironforge` script in the guards script loader.
- Restricted responses to Alliance players using `pPlayer->GetTeam() == ALLIANCE`.

## Supported responses

Tested targeted player emotes:

- `/wave`
- `/salute`
- `/kiss`
- `/shy`
- `/rude`
- `/rasp`
- `/chicken`

The guard performs the response animation and sends the visible monster emote chat text.

## Scope

This is deliberately Ironforge-only.

The existing generic guard script remains unaffected. Other city guards do not gain this behavior from this patch.

## Testing

Tested in-game with Ironforge Guard entry `5595`.

Confirmed:

- Alliance players receive responses.
- Horde players do not receive friendly responses.
- One player emote triggers one guard response.
- Guard response animation is visible.
- Guard response chat text is visible.
- `/wave`, `/salute`, `/kiss`, `/shy`, `/rude`, `/rasp`, and `/chicken` all work.
- Other guards still bound to `guard_generic` are unaffected.

## Notes

The database binding change is in the matching database PR. This ScriptDev3 PR should be merged before or alongside the DB update that binds entry `5595` to `guard_ironforge`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/95)
<!-- Reviewable:end -->
