### PR TITLE
LivingWorld: add partial-grid scan guard

### DIFF
--- a/include/sc_grid_searchers.cpp
+++ b/include/sc_grid_searchers.cpp
@@ -89,7 +89,7 @@ Creature* GetClosestCreatureWithEntry(WorldObject* pSource, uint32 uiEntry, floa
  * @param uiEntry Entry ID of the GameObject.
  * @param fMaxSearchRange Maximum search range.
  */
-static void CheckPartialGridScanAnomaly(WorldObject* pSource)
+static void CheckPartialGridScanAnomaly(WorldObject* pSource, const char* tag)
 {
     if (!pSource || !pSource->GetMap())
     {
@@ -107,22 +107,32 @@ static void CheckPartialGridScanAnomaly(WorldObject* pSource)
         return;
     }
 
+    // Always count every real anomaly; rate-limit only the log line.
+    ++pSource->GetMap()->CellEnvStats().anomalyScanPartial;
+
     static std::set<uint64> warnedGrids;
-    uint64 gridKey = (uint64(pSource->GetMapId()) << 32) | (uint64(cell.GridX()) << 16) | uint64(cell.GridY());
+    uint64 tagHash = 5381;
+    for (const char* c = tag; c && *c; ++c)
+    {
+        tagHash = ((tagHash << 5) + tagHash) + uint64(*c);
+    }
+    uint64 gridKey = (uint64(pSource->GetMapId()) << 32)
+                     | (uint64(cell.GridX()) << 16)
+                     | uint64(cell.GridY());
+    gridKey ^= tagHash;
     if (warnedGrids.find(gridKey) != warnedGrids.end())
     {
         return;
     }
 
     warnedGrids.insert(gridKey);
-    ++pSource->GetMap()->CellEnvStats().anomalyScanPartial;
-    sLog.outError("[CellEnvelope][ANOMALY] whole-grid scan on partial grid[%u,%u] map %u — results may be incomplete",
-                  cell.GridX(), cell.GridY(), pSource->GetMapId());
+    sLog.outError("[CellEnvelope][ANOMALY] whole-grid scan on partial grid[%u,%u] map %u (tag: %s) — results may be incomplete",
+                  cell.GridX(), cell.GridY(), pSource->GetMapId(), tag ? tag : "?");
 }
 
 void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& lList , WorldObject* pSource, uint32 uiEntry, float fMaxSearchRange)
 {
-    CheckPartialGridScanAnomaly(pSource);
+    CheckPartialGridScanAnomaly(pSource, "GO");
 
     MaNGOS::GameObjectEntryInPosRangeCheck check(*pSource, uiEntry, pSource->GetPositionX(), pSource->GetPositionY(), pSource->GetPositionZ(), fMaxSearchRange);
     MaNGOS::GameObjectListSearcher<MaNGOS::GameObjectEntryInPosRangeCheck> searcher(lList, check);
@@ -142,7 +152,7 @@ void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& lList , WorldObjec
  */
 void GetCreatureListWithEntryInGrid(std::list<Creature*>& lList, WorldObject* pSource, uint32 uiEntry, float fMaxSearchRange)
 {
-    CheckPartialGridScanAnomaly(pSource);
+    CheckPartialGridScanAnomaly(pSource, "Creature");
 
     MaNGOS::AllCreaturesOfEntryInRangeCheck check(pSource, uiEntry, fMaxSearchRange);
     MaNGOS::CreatureListSearcher<MaNGOS::AllCreaturesOfEntryInRangeCheck> searcher(lList, check);

--- a/include/sc_grid_searchers.cpp
+++ b/include/sc_grid_searchers.cpp
@@ -89,6 +89,7 @@ Creature* GetClosestCreatureWithEntry(WorldObject* pSource, uint32 uiEntry, floa
  * @param uiEntry Entry ID of the GameObject.
  * @param fMaxSearchRange Maximum search range.
  */
+#if defined(CLASSIC)
 static void CheckPartialGridScanAnomaly(WorldObject* pSource, const char* tag)
 {
     if (!pSource || !pSource->GetMap())
@@ -129,6 +130,9 @@ static void CheckPartialGridScanAnomaly(WorldObject* pSource, const char* tag)
     sLog.outError("[CellEnvelope][ANOMALY] whole-grid scan on partial grid[%u,%u] map %u (tag: %s) — results may be incomplete",
                   cell.GridX(), cell.GridY(), pSource->GetMapId(), tag ? tag : "?");
 }
+#else
+static void CheckPartialGridScanAnomaly(WorldObject* /*pSource*/, const char* /*tag*/) {}
+#endif
 
 void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& lList , WorldObject* pSource, uint32 uiEntry, float fMaxSearchRange)
 {

--- a/include/sc_grid_searchers.cpp
+++ b/include/sc_grid_searchers.cpp
@@ -30,6 +30,7 @@
 #include "CellImpl.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+#include "World.h"
 
 /**
  * @brief Returns the closest GameObject with a specific entry within a given range.
@@ -88,8 +89,41 @@ Creature* GetClosestCreatureWithEntry(WorldObject* pSource, uint32 uiEntry, floa
  * @param uiEntry Entry ID of the GameObject.
  * @param fMaxSearchRange Maximum search range.
  */
+static void CheckPartialGridScanAnomaly(WorldObject* pSource)
+{
+    if (!pSource || !pSource->GetMap())
+    {
+        return;
+    }
+    if (!sWorld.getConfig(CONFIG_BOOL_LIVINGWORLD_CELL_ENVELOPE_LOAD))
+    {
+        return;
+    }
+
+    CellPair p = MaNGOS::ComputeCellPair(pSource->GetPositionX(), pSource->GetPositionY());
+    Cell cell(p);
+    if (!pSource->GetMap()->IsGridEnvelope(cell.GridX(), cell.GridY()))
+    {
+        return;
+    }
+
+    static std::set<uint64> warnedGrids;
+    uint64 gridKey = (uint64(pSource->GetMapId()) << 32) | (uint64(cell.GridX()) << 16) | uint64(cell.GridY());
+    if (warnedGrids.find(gridKey) != warnedGrids.end())
+    {
+        return;
+    }
+
+    warnedGrids.insert(gridKey);
+    ++pSource->GetMap()->CellEnvStats().anomalyScanPartial;
+    sLog.outError("[CellEnvelope][ANOMALY] whole-grid scan on partial grid[%u,%u] map %u — results may be incomplete",
+                  cell.GridX(), cell.GridY(), pSource->GetMapId());
+}
+
 void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& lList , WorldObject* pSource, uint32 uiEntry, float fMaxSearchRange)
 {
+    CheckPartialGridScanAnomaly(pSource);
+
     MaNGOS::GameObjectEntryInPosRangeCheck check(*pSource, uiEntry, pSource->GetPositionX(), pSource->GetPositionY(), pSource->GetPositionZ(), fMaxSearchRange);
     MaNGOS::GameObjectListSearcher<MaNGOS::GameObjectEntryInPosRangeCheck> searcher(lList, check);
 
@@ -108,6 +142,8 @@ void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& lList , WorldObjec
  */
 void GetCreatureListWithEntryInGrid(std::list<Creature*>& lList, WorldObject* pSource, uint32 uiEntry, float fMaxSearchRange)
 {
+    CheckPartialGridScanAnomaly(pSource);
+
     MaNGOS::AllCreaturesOfEntryInRangeCheck check(pSource, uiEntry, fMaxSearchRange);
     MaNGOS::CreatureListSearcher<MaNGOS::AllCreaturesOfEntryInRangeCheck> searcher(lList, check);
 


### PR DESCRIPTION
## Summary
- Flags whole-grid SD3 scans when they run over partially loaded LivingWorld cell-envelope grids.
- Improves anomaly key/counting fidelity for LivingWorld diagnostics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/96)
<!-- Reviewable:end -->
