### PR TITLE
Expansion-guarded accessors for mangos-zero DBC alignment (+ cross-core GetPowerType fix)

### DIFF
--- a/include/sc_creature.cpp
+++ b/include/sc_creature.cpp
@@ -417,18 +417,18 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
         }
 
         // Check if the spell meets our range requirements
-        if (fRangeMin && pTempRange->maxRange < fRangeMin)
+        if (fRangeMin && pTempRange->RangeMax < fRangeMin)
         {
             continue;
         }
 
-        if (fRangeMax && pTempRange->maxRange > fRangeMax)
+        if (fRangeMax && pTempRange->RangeMax > fRangeMax)
         {
             continue;
         }
 
         // Check if our target is in range
-        if (m_creature->IsWithinDistInMap(pTarget, pTempRange->minRange) || !m_creature->IsWithinDistInMap(pTarget, pTempRange->maxRange))
+        if (m_creature->IsWithinDistInMap(pTarget, pTempRange->RangeMin) || !m_creature->IsWithinDistInMap(pTarget, pTempRange->RangeMax))
         {
             continue;
         }
@@ -493,7 +493,7 @@ bool ScriptedAI::CanCast(Unit* pTarget, SpellEntry const* pSpellEntry, bool bTri
     }
 
     // Unit is out of range of this spell
-    if (!m_creature->IsInRange(pTarget, pTempRange->minRange, pTempRange->maxRange))
+    if (!m_creature->IsInRange(pTarget, pTempRange->RangeMin, pTempRange->RangeMax))
     {
         return false;
     }

--- a/include/sc_creature.cpp
+++ b/include/sc_creature.cpp
@@ -376,7 +376,7 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
 #if defined (CATA) || defined (MISTS)
         if (uiPowerCostMin &&  pTempSpell->GetManaCost() < uiPowerCostMin)
 #else
-        if (uiPowerCostMin &&  pTempSpell->manaCost < uiPowerCostMin)
+        if (uiPowerCostMin &&  pTempSpell->ManaCost < uiPowerCostMin)
 #endif
         {
             continue;
@@ -385,7 +385,7 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
 #if defined (CATA) || defined (MISTS)
         if (uiPowerCostMax && pTempSpell->GetManaCost() > uiPowerCostMax)
 #else
-        if (uiPowerCostMax && pTempSpell->manaCost > uiPowerCostMax)
+        if (uiPowerCostMax && pTempSpell->ManaCost > uiPowerCostMax)
 #endif
         {
             continue;
@@ -393,11 +393,11 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
 
         // Continue if we don't have the mana to actually cast this spell
 #if defined (CATA)
-        if (pTempSpell->GetManaCost() > m_creature->GetPower((Powers)pTempSpell->powerType))
+        if (pTempSpell->GetManaCost() > m_creature->GetPower((Powers)pTempSpell->PowerType))
 #elif defined (MISTS)
         if (pTempSpell->GetManaCost() > m_creature->GetPower((Powers)pTempSpell->GetPowerType()))
 #else
-        if (pTempSpell->manaCost > m_creature->GetPower((Powers)pTempSpell->powerType))
+        if (pTempSpell->ManaCost > m_creature->GetPower((Powers)pTempSpell->PowerType))
 #endif
 
         {
@@ -408,7 +408,7 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
 #if defined(MISTS)
         pTempRange = GetSpellRangeStore()->LookupEntry(pTempSpell->GetRangeIndex());
 #else
-        pTempRange = GetSpellRangeStore()->LookupEntry(pTempSpell->rangeIndex);
+        pTempRange = GetSpellRangeStore()->LookupEntry(pTempSpell->RangeIndex);
 #endif
         // Spell has invalid range store so we can't use it
         if (!pTempRange)
@@ -470,11 +470,11 @@ bool ScriptedAI::CanCast(Unit* pTarget, SpellEntry const* pSpellEntry, bool bTri
 
     // Check for power
 #if defined (CATA)
-    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->powerType) < pSpellEntry->GetManaCost())
+    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->PowerType) < pSpellEntry->GetManaCost())
 #elif defined (MISTS)
     if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->GetPowerType()) < pSpellEntry->GetManaCost())
 #else
-    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->powerType) < pSpellEntry->manaCost)
+    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->PowerType) < pSpellEntry->ManaCost)
 #endif
     {
         return false;
@@ -483,7 +483,7 @@ bool ScriptedAI::CanCast(Unit* pTarget, SpellEntry const* pSpellEntry, bool bTri
 #if defined(MISTS)
     SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(pSpellEntry->GetRangeIndex());
 #else
-    SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(pSpellEntry->rangeIndex);
+    SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(pSpellEntry->RangeIndex);
 #endif
 
     // Spell has invalid range store so we can't use it
@@ -536,7 +536,7 @@ void FillSpellSummary()
 #if defined (CATA) || defined (MISTS)
             if (pTempSpell->GetEffectImplicitTargetAByIndex(SpellEffectIndex(j)) == TARGET_SELF)
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_SELF)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF)
 #endif
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SELF - 1);
@@ -550,8 +550,8 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_ENEMY - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_ENEMY - 1);
             }
@@ -567,10 +567,10 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_ENEMY - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_ENEMY - 1);
             }
@@ -588,12 +588,12 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_ENEMY - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_ENEMY - 1);
             }
@@ -608,9 +608,9 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_FRIEND - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_SELF ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_SINGLE_PARTY)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_PARTY)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_FRIEND - 1);
             }
@@ -625,9 +625,9 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_FRIEND - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_FRIEND - 1);
             }
@@ -645,12 +645,12 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_FRIEND - 1);
             }
 #else
-            if (pTempSpell->EffectImplicitTargetA[j] == TARGET_SELF ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_SINGLE_PARTY ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
-                pTempSpell->EffectImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
+            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_PARTY ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
+                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_FRIEND - 1);
             }
@@ -688,7 +688,7 @@ void FillSpellSummary()
             if (pTempSpell->Effect[j] == SPELL_EFFECT_HEAL ||
                 pTempSpell->Effect[j] == SPELL_EFFECT_HEAL_MAX_HEALTH ||
                 pTempSpell->Effect[j] == SPELL_EFFECT_HEAL_MECHANICAL ||
-                (pTempSpell->Effect[j] == SPELL_EFFECT_APPLY_AURA  && pTempSpell->EffectApplyAuraName[j] == 8))
+                (pTempSpell->Effect[j] == SPELL_EFFECT_APPLY_AURA  && pTempSpell->EffectAura[j] == 8))
             {
                 SpellSummary[i].Effects |= 1 << (SELECT_EFFECT_HEALING - 1);
             }

--- a/include/sc_creature.cpp
+++ b/include/sc_creature.cpp
@@ -150,7 +150,7 @@ void ScriptedAI::UpdateAI(const uint32 /*uiDiff*/)
     const SpellEntry* potentialSpell = m_creature->ReachWithSpellAttack(victim);
     if (potentialSpell)
     {
-        m_creature->CastSpell(victim, potentialSpell->Id, true);
+        m_creature->CastSpell(victim, SD3_SpellId(potentialSpell), true);
     }
 #endif
 }
@@ -373,43 +373,24 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
         }
 
         // Make sure that the spell uses the requested amount of power
-#if defined (CATA) || defined (MISTS)
-        if (uiPowerCostMin &&  pTempSpell->GetManaCost() < uiPowerCostMin)
-#else
-        if (uiPowerCostMin &&  pTempSpell->ManaCost < uiPowerCostMin)
-#endif
+        if (uiPowerCostMin && SD3_SpellManaCost(pTempSpell) < uiPowerCostMin)
         {
             continue;
         }
 
-#if defined (CATA) || defined (MISTS)
-        if (uiPowerCostMax && pTempSpell->GetManaCost() > uiPowerCostMax)
-#else
-        if (uiPowerCostMax && pTempSpell->ManaCost > uiPowerCostMax)
-#endif
+        if (uiPowerCostMax && SD3_SpellManaCost(pTempSpell) > uiPowerCostMax)
         {
             continue;
         }
 
         // Continue if we don't have the mana to actually cast this spell
-#if defined (CATA)
-        if (pTempSpell->GetManaCost() > m_creature->GetPower((Powers)pTempSpell->PowerType))
-#elif defined (MISTS)
-        if (pTempSpell->GetManaCost() > m_creature->GetPower((Powers)pTempSpell->GetPowerType()))
-#else
-        if (pTempSpell->ManaCost > m_creature->GetPower((Powers)pTempSpell->PowerType))
-#endif
-
+        if (SD3_SpellManaCost(pTempSpell) > m_creature->GetPower((Powers)SD3_SpellPowerType(pTempSpell)))
         {
             continue;
         }
 
         // Get the Range
-#if defined(MISTS)
-        pTempRange = GetSpellRangeStore()->LookupEntry(pTempSpell->GetRangeIndex());
-#else
-        pTempRange = GetSpellRangeStore()->LookupEntry(pTempSpell->RangeIndex);
-#endif
+        pTempRange = GetSpellRangeStore()->LookupEntry(SD3_SpellRangeIndex(pTempSpell));
         // Spell has invalid range store so we can't use it
         if (!pTempRange)
         {
@@ -469,22 +450,12 @@ bool ScriptedAI::CanCast(Unit* pTarget, SpellEntry const* pSpellEntry, bool bTri
     }
 
     // Check for power
-#if defined (CATA)
-    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->PowerType) < pSpellEntry->GetManaCost())
-#elif defined (MISTS)
-    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->GetPowerType()) < pSpellEntry->GetManaCost())
-#else
-    if (!bTriggered && m_creature->GetPower((Powers)pSpellEntry->PowerType) < pSpellEntry->ManaCost)
-#endif
+    if (!bTriggered && m_creature->GetPower((Powers)SD3_SpellPowerType(pSpellEntry)) < SD3_SpellManaCost(pSpellEntry))
     {
         return false;
     }
 
-#if defined(MISTS)
-    SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(pSpellEntry->GetRangeIndex());
-#else
-    SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(pSpellEntry->RangeIndex);
-#endif
+    SpellRangeEntry const* pTempRange = GetSpellRangeStore()->LookupEntry(SD3_SpellRangeIndex(pSpellEntry));
 
     // Spell has invalid range store so we can't use it
     if (!pTempRange)
@@ -536,7 +507,7 @@ void FillSpellSummary()
 #if defined (CATA) || defined (MISTS)
             if (pTempSpell->GetEffectImplicitTargetAByIndex(SpellEffectIndex(j)) == TARGET_SELF)
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SELF)
 #endif
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SELF - 1);
@@ -550,8 +521,8 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_ENEMY - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CHAIN_DAMAGE ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CURRENT_ENEMY_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_ENEMY - 1);
             }
@@ -567,10 +538,10 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_ENEMY - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CASTER_COORDINATES ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_ENEMY - 1);
             }
@@ -588,12 +559,12 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_ENEMY - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_CHAIN_DAMAGE ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CURRENT_ENEMY_COORDINATES ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CHAIN_DAMAGE ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CURRENT_ENEMY_COORDINATES ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA_INSTANT ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CASTER_COORDINATES ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_ENEMY_IN_AREA_CHANNELED)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_ENEMY - 1);
             }
@@ -608,9 +579,9 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_FRIEND - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_PARTY)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SELF ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SINGLE_FRIEND ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SINGLE_PARTY)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_SINGLE_FRIEND - 1);
             }
@@ -625,9 +596,9 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_FRIEND - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_PARTY_AROUND_CASTER ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_AREAEFFECT_PARTY ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CASTER_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_AOE_FRIEND - 1);
             }
@@ -645,12 +616,12 @@ void FillSpellSummary()
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_FRIEND - 1);
             }
 #else
-            if (pTempSpell->ImplicitTargetA[j] == TARGET_SELF ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_FRIEND ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_SINGLE_PARTY ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_ALL_PARTY_AROUND_CASTER ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_AREAEFFECT_PARTY ||
-                pTempSpell->ImplicitTargetA[j] == TARGET_CASTER_COORDINATES)
+            if (SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SELF ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SINGLE_FRIEND ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_SINGLE_PARTY ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_ALL_PARTY_AROUND_CASTER ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_AREAEFFECT_PARTY ||
+                SD3_SpellEffectImplicitTargetA(pTempSpell, j) == TARGET_CASTER_COORDINATES)
             {
                 SpellSummary[i].Targets |= 1 << (SELECT_TARGET_ANY_FRIEND - 1);
             }
@@ -688,7 +659,7 @@ void FillSpellSummary()
             if (pTempSpell->Effect[j] == SPELL_EFFECT_HEAL ||
                 pTempSpell->Effect[j] == SPELL_EFFECT_HEAL_MAX_HEALTH ||
                 pTempSpell->Effect[j] == SPELL_EFFECT_HEAL_MECHANICAL ||
-                (pTempSpell->Effect[j] == SPELL_EFFECT_APPLY_AURA  && pTempSpell->EffectAura[j] == 8))
+                (pTempSpell->Effect[j] == SPELL_EFFECT_APPLY_AURA  && SD3_SpellEffectApplyAuraName(pTempSpell, j) == 8))
             {
                 SpellSummary[i].Effects |= 1 << (SELECT_EFFECT_HEALING - 1);
             }

--- a/include/sc_creature.cpp
+++ b/include/sc_creature.cpp
@@ -398,18 +398,18 @@ SpellEntry const* ScriptedAI::SelectSpell(Unit* pTarget, int32 uiSchool, int32 i
         }
 
         // Check if the spell meets our range requirements
-        if (fRangeMin && pTempRange->RangeMax < fRangeMin)
+        if (fRangeMin && SD3_SpellRangeMax(pTempRange) < fRangeMin)
         {
             continue;
         }
 
-        if (fRangeMax && pTempRange->RangeMax > fRangeMax)
+        if (fRangeMax && SD3_SpellRangeMax(pTempRange) > fRangeMax)
         {
             continue;
         }
 
         // Check if our target is in range
-        if (m_creature->IsWithinDistInMap(pTarget, pTempRange->RangeMin) || !m_creature->IsWithinDistInMap(pTarget, pTempRange->RangeMax))
+        if (m_creature->IsWithinDistInMap(pTarget, SD3_SpellRangeMin(pTempRange)) || !m_creature->IsWithinDistInMap(pTarget, SD3_SpellRangeMax(pTempRange)))
         {
             continue;
         }
@@ -464,7 +464,7 @@ bool ScriptedAI::CanCast(Unit* pTarget, SpellEntry const* pSpellEntry, bool bTri
     }
 
     // Unit is out of range of this spell
-    if (!m_creature->IsInRange(pTarget, pTempRange->RangeMin, pTempRange->RangeMax))
+    if (!m_creature->IsInRange(pTarget, SD3_SpellRangeMin(pTempRange), SD3_SpellRangeMax(pTempRange)))
     {
         return false;
     }

--- a/include/sc_creature.h
+++ b/include/sc_creature.h
@@ -107,6 +107,37 @@ inline uint32 SD3_SpellEffectApplyAuraName(SpellEntry const* pSpell, uint8 index
 }
 #endif
 
+// AreaTriggerEntry / SpellRangeEntry accessors (cross-expansion compatibility).
+// mangos-zero (CLASSIC) renamed these DBC fields to their .dbd names; the other
+// cores keep the legacy names. Same per-expansion resolution as the SpellEntry
+// helpers above so shared scripts compile on every core.
+inline uint32 SD3_AreaTriggerId(AreaTriggerEntry const* pAt)
+{
+#if defined (CLASSIC)
+    return pAt->ID;
+#else
+    return pAt->id;
+#endif
+}
+
+inline float SD3_SpellRangeMin(SpellRangeEntry const* pRange)
+{
+#if defined (CLASSIC)
+    return pRange->RangeMin;
+#else
+    return pRange->minRange;
+#endif
+}
+
+inline float SD3_SpellRangeMax(SpellRangeEntry const* pRange)
+{
+#if defined (CLASSIC)
+    return pRange->RangeMax;
+#else
+    return pRange->maxRange;
+#endif
+}
+
 // Spell targets used by SelectSpell
 enum SelectTarget
 {

--- a/include/sc_creature.h
+++ b/include/sc_creature.h
@@ -30,6 +30,83 @@
 #include "Chat.h"
 #include "DBCStores.h"  // Mostly only used for Lookup access, but a few cases really do use the DBC-Stores
 
+// -------------------------------------------------------------------------
+// SpellEntry field accessors (cross-expansion compatibility)
+//
+// ScriptDev3 is a single repository shared by every mangos core (Zero/One/Two/
+// Three/Four). mangos-zero (CLASSIC) aligned its SpellEntry struct field names to
+// the build-exact 1.12 .dbd names; the other cores keep the legacy field names
+// (and the later cores expose GetXxx() accessor methods). These helpers resolve
+// each field per expansion so shared scripts compile and behave identically on
+// every core - each build only ever compiles its own branch.
+// -------------------------------------------------------------------------
+inline uint32 SD3_SpellId(SpellEntry const* pSpell)
+{
+#if defined (CLASSIC)
+    return pSpell->ID;
+#else
+    return pSpell->Id;
+#endif
+}
+
+inline uint32 SD3_SpellManaCost(SpellEntry const* pSpell)
+{
+#if defined (CATA) || defined (MISTS)
+    return pSpell->GetManaCost();
+#elif defined (CLASSIC)
+    return pSpell->ManaCost;
+#else   // TBC, WOTLK
+    return pSpell->manaCost;
+#endif
+}
+
+inline uint32 SD3_SpellPowerType(SpellEntry const* pSpell)
+{
+#if defined (MISTS)
+    return pSpell->GetPowerType();
+#elif defined (CLASSIC)
+    return pSpell->PowerType;
+#else   // TBC, WOTLK, CATA
+    return pSpell->powerType;
+#endif
+}
+
+inline uint32 SD3_SpellRangeIndex(SpellEntry const* pSpell)
+{
+#if defined (MISTS)
+    return pSpell->GetRangeIndex();
+#elif defined (CLASSIC)
+    return pSpell->RangeIndex;
+#else   // TBC, WOTLK, CATA
+    return pSpell->rangeIndex;
+#endif
+}
+
+// Effect-array accessors - used only on the non-CATA/MISTS path (CATA/MISTS
+// expose GetEffect*ByIndex() with their own SpellEffect null-checks and stay
+// inline at the call sites). CATA/MISTS SpellEntry has no EffectImplicitTargetA/
+// EffectApplyAuraName member at all, so these helpers are only defined for the
+// cores that have those fields (Zero/One/Two).
+#if !defined (CATA) && !defined (MISTS)
+inline uint32 SD3_SpellEffectImplicitTargetA(SpellEntry const* pSpell, uint8 index)
+{
+#if defined (CLASSIC)
+    return pSpell->ImplicitTargetA[index];
+#else   // TBC, WOTLK
+    return pSpell->EffectImplicitTargetA[index];
+#endif
+}
+
+inline uint32 SD3_SpellEffectApplyAuraName(SpellEntry const* pSpell, uint8 index)
+{
+#if defined (CLASSIC)
+    return pSpell->EffectAura[index];
+#else   // TBC, WOTLK
+    return pSpell->EffectApplyAuraName[index];
+#endif
+}
+#endif
+
 // Spell targets used by SelectSpell
 enum SelectTarget
 {

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -278,7 +278,7 @@ struct at_ring_of_law : public AreaTriggerScript
             pInstance->SetData(TYPE_RING_OF_LAW, pInstance->GetData(TYPE_RING_OF_LAW) == DATA_BANNER_BEFORE_EVENT ? SPECIAL : IN_PROGRESS);
 
             pPlayer->SummonCreature(NPC_GRIMSTONE, aSpawnPositions[POS_GRIMSTONE][0], aSpawnPositions[POS_GRIMSTONE][1], aSpawnPositions[POS_GRIMSTONE][2], aSpawnPositions[POS_GRIMSTONE][3], TEMPSPAWN_DEAD_DESPAWN, 0);
-            pInstance->SetData(TYPE_SIGNAL, pAt->id);
+            pInstance->SetData(TYPE_SIGNAL, pAt->ID);
             pInstance->SetArenaCenterCoords(pAt->x, pAt->y, pAt->z);
 
             return false;

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -1858,7 +1858,7 @@ struct boss_plugger_spazzringAI : public ScriptedAI
     {
         if (pCaster->GetTypeId() == TYPEID_PLAYER)
         {
-            if (pSpell->Id == SPELL_PICKPOCKET)
+            if (pSpell->ID == SPELL_PICKPOCKET)
             {
                 m_uiPickpocketTimer = 5000;
             }

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -1858,7 +1858,7 @@ struct boss_plugger_spazzringAI : public ScriptedAI
     {
         if (pCaster->GetTypeId() == TYPEID_PLAYER)
         {
-            if (pSpell->ID == SPELL_PICKPOCKET)
+            if (SD3_SpellId(pSpell) == SPELL_PICKPOCKET)
             {
                 m_uiPickpocketTimer = 5000;
             }

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -278,7 +278,7 @@ struct at_ring_of_law : public AreaTriggerScript
             pInstance->SetData(TYPE_RING_OF_LAW, pInstance->GetData(TYPE_RING_OF_LAW) == DATA_BANNER_BEFORE_EVENT ? SPECIAL : IN_PROGRESS);
 
             pPlayer->SummonCreature(NPC_GRIMSTONE, aSpawnPositions[POS_GRIMSTONE][0], aSpawnPositions[POS_GRIMSTONE][1], aSpawnPositions[POS_GRIMSTONE][2], aSpawnPositions[POS_GRIMSTONE][3], TEMPSPAWN_DEAD_DESPAWN, 0);
-            pInstance->SetData(TYPE_SIGNAL, pAt->ID);
+            pInstance->SetData(TYPE_SIGNAL, SD3_AreaTriggerId(pAt));
             pInstance->SetArenaCenterCoords(pAt->x, pAt->y, pAt->z);
 
             return false;

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
@@ -943,7 +943,7 @@ struct at_blackrock_spire : public AreaTriggerScript
             return false;
         }
 
-        switch (pAt->id)
+        switch (pAt->ID)
         {
             case AREATRIGGER_ENTER_UBRS:
                 if (InstanceData* pInstance = pPlayer->GetInstanceData())

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackrock_spire/instance_blackrock_spire.cpp
@@ -943,7 +943,7 @@ struct at_blackrock_spire : public AreaTriggerScript
             return false;
         }
 
-        switch (pAt->ID)
+        switch (SD3_AreaTriggerId(pAt))
         {
             case AREATRIGGER_ENTER_UBRS:
                 if (InstanceData* pInstance = pPlayer->GetInstanceData())

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
@@ -423,7 +423,7 @@ struct at_vaelastrasz : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->id == AREATRIGGER_VAEL_INTRO)
+        if (pAt->ID == AREATRIGGER_VAEL_INTRO)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {

--- a/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
@@ -423,7 +423,7 @@ struct at_vaelastrasz : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->ID == AREATRIGGER_VAEL_INTRO)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_VAEL_INTRO)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {

--- a/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_ragnaros.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_ragnaros.cpp
@@ -203,7 +203,7 @@ struct boss_ragnaros : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // As Majordomo is now killed, the last timer (until attacking) must be handled with ragnaros script
-            if (pSpell->Id == SPELL_ELEMENTAL_FIRE_KILL && pTarget->GetTypeId() == TYPEID_UNIT && pTarget->GetEntry() == NPC_MAJORDOMO)
+            if (pSpell->ID == SPELL_ELEMENTAL_FIRE_KILL && pTarget->GetTypeId() == TYPEID_UNIT && pTarget->GetEntry() == NPC_MAJORDOMO)
             {
                 m_uiEnterCombatTimer = 10000;
             }

--- a/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_ragnaros.cpp
+++ b/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_ragnaros.cpp
@@ -203,7 +203,7 @@ struct boss_ragnaros : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // As Majordomo is now killed, the last timer (until attacking) must be handled with ragnaros script
-            if (pSpell->ID == SPELL_ELEMENTAL_FIRE_KILL && pTarget->GetTypeId() == TYPEID_UNIT && pTarget->GetEntry() == NPC_MAJORDOMO)
+            if (SD3_SpellId(pSpell) == SPELL_ELEMENTAL_FIRE_KILL && pTarget->GetTypeId() == TYPEID_UNIT && pTarget->GetEntry() == NPC_MAJORDOMO)
             {
                 m_uiEnterCombatTimer = 10000;
             }

--- a/scripts/eastern_kingdoms/burning_steppes.cpp
+++ b/scripts/eastern_kingdoms/burning_steppes.cpp
@@ -682,7 +682,7 @@ struct npc_klinfran_the_crazed : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell && pSpell->ID == 14277)   // Scorpid Sting (Rank 4)
+            if (pSpell && SD3_SpellId(pSpell) == 14277)   // Scorpid Sting (Rank 4)
             {
                 m_creature->RemoveAurasDueToSpell(SPELL_DEMONIC_FRENZY);
                 DoCastSpellIfCan(m_creature, SPELL_ENTROPIC_STING, CAST_TRIGGERED);

--- a/scripts/eastern_kingdoms/burning_steppes.cpp
+++ b/scripts/eastern_kingdoms/burning_steppes.cpp
@@ -682,7 +682,7 @@ struct npc_klinfran_the_crazed : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell && pSpell->Id == 14277)   // Scorpid Sting (Rank 4)
+            if (pSpell && pSpell->ID == 14277)   // Scorpid Sting (Rank 4)
             {
                 m_creature->RemoveAurasDueToSpell(SPELL_DEMONIC_FRENZY);
                 DoCastSpellIfCan(m_creature, SPELL_ENTROPIC_STING, CAST_TRIGGERED);

--- a/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
+++ b/scripts/eastern_kingdoms/karazhan/boss_shade_of_aran.cpp
@@ -229,11 +229,7 @@ struct boss_shade_of_aran : public CreatureScript
             }
 
             // Start drinking when below 20% mana
-#if !defined(MISTS)
-            if (!m_bIsDrinking && m_creature->powerType == POWER_MANA && (m_creature->GetPower(POWER_MANA) * 100 / m_creature->GetMaxPower(POWER_MANA)) < 20)
-#else
             if (!m_bIsDrinking && m_creature->GetPowerType() == POWER_MANA && (m_creature->GetPower(POWER_MANA) * 100 / m_creature->GetMaxPower(POWER_MANA)) < 20)
-#endif
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_MASS_POLYMORPH) == CAST_OK)
                 {

--- a/scripts/eastern_kingdoms/naxxramas/boss_faerlina.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/boss_faerlina.cpp
@@ -146,7 +146,7 @@ struct boss_faerlina : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpellEntry) override
         {
             // Check if we hit with Widow's Embrave
-            if (pSpellEntry->ID == SPELL_WIDOWS_EMBRACE)
+            if (SD3_SpellId(pSpellEntry) == SPELL_WIDOWS_EMBRACE)
             {
                 //bool bIsFrenzyRemove = false;
 

--- a/scripts/eastern_kingdoms/naxxramas/boss_faerlina.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/boss_faerlina.cpp
@@ -146,7 +146,7 @@ struct boss_faerlina : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpellEntry) override
         {
             // Check if we hit with Widow's Embrave
-            if (pSpellEntry->Id == SPELL_WIDOWS_EMBRACE)
+            if (pSpellEntry->ID == SPELL_WIDOWS_EMBRACE)
             {
                 //bool bIsFrenzyRemove = false;
 

--- a/scripts/eastern_kingdoms/naxxramas/boss_grobbulus.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/boss_grobbulus.cpp
@@ -153,7 +153,7 @@ struct boss_grobbulus : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if ((pSpell->Id == SPELL_SLIME_SPRAY) && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if ((pSpell->ID == SPELL_SLIME_SPRAY) && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 m_creature->SummonCreature(NPC_FALLOUT_SLIME, pTarget->GetPositionX(), pTarget->GetPositionY(), pTarget->GetPositionZ(), 0.0f, TEMPSPAWN_TIMED_OOC_DESPAWN, 10 * IN_MILLISECONDS);
             }

--- a/scripts/eastern_kingdoms/naxxramas/boss_grobbulus.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/boss_grobbulus.cpp
@@ -153,7 +153,7 @@ struct boss_grobbulus : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if ((pSpell->ID == SPELL_SLIME_SPRAY) && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if ((SD3_SpellId(pSpell) == SPELL_SLIME_SPRAY) && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 m_creature->SummonCreature(NPC_FALLOUT_SLIME, pTarget->GetPositionX(), pTarget->GetPositionY(), pTarget->GetPositionZ(), 0.0f, TEMPSPAWN_TIMED_OOC_DESPAWN, 10 * IN_MILLISECONDS);
             }

--- a/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -906,7 +906,7 @@ struct is_naxxramas : public InstanceScript
             // kel
             void SetChamberCenterCoords(AreaTriggerEntry const *at)
             {
-                m_uiChanberCenterAT = at->ID;
+                m_uiChanberCenterAT = SD3_AreaTriggerId(at);
             }
 
             void GetChamberCenterCoords(float& fX, float& fY, float& fZ) { fX = m_fChamberCenterX; fY = m_fChamberCenterY; fZ = m_fChamberCenterZ; }
@@ -1070,7 +1070,7 @@ struct at_naxxramas : public AreaTriggerScript
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
         ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData();
-        switch (pAt->ID)
+        switch (SD3_AreaTriggerId(pAt))
         {
             case AREATRIGGER_KELTHUZAD:
                 if (pPlayer->isGameMaster() || !pPlayer->IsAlive())
@@ -1080,7 +1080,7 @@ struct at_naxxramas : public AreaTriggerScript
 
                 if (pInstance)
                 {
-                    pInstance->SetData(TYPE_SIGNAL_1, pAt->ID); //it is unclear why do not hardcode AREATRIGGER_KELTHUZAD constant into the single place it used: boss_kelthuzad::JustSummoned
+                    pInstance->SetData(TYPE_SIGNAL_1, SD3_AreaTriggerId(pAt)); //it is unclear why do not hardcode AREATRIGGER_KELTHUZAD constant into the single place it used: boss_kelthuzad::JustSummoned
 
                     if (pInstance->GetData(TYPE_KELTHUZAD) == NOT_STARTED)
                     {

--- a/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
+++ b/scripts/eastern_kingdoms/naxxramas/instance_naxxramas.cpp
@@ -906,7 +906,7 @@ struct is_naxxramas : public InstanceScript
             // kel
             void SetChamberCenterCoords(AreaTriggerEntry const *at)
             {
-                m_uiChanberCenterAT = at->id;
+                m_uiChanberCenterAT = at->ID;
             }
 
             void GetChamberCenterCoords(float& fX, float& fY, float& fZ) { fX = m_fChamberCenterX; fY = m_fChamberCenterY; fZ = m_fChamberCenterZ; }
@@ -1070,7 +1070,7 @@ struct at_naxxramas : public AreaTriggerScript
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
         ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData();
-        switch (pAt->id)
+        switch (pAt->ID)
         {
             case AREATRIGGER_KELTHUZAD:
                 if (pPlayer->isGameMaster() || !pPlayer->IsAlive())
@@ -1080,7 +1080,7 @@ struct at_naxxramas : public AreaTriggerScript
 
                 if (pInstance)
                 {
-                    pInstance->SetData(TYPE_SIGNAL_1, pAt->id); //it is unclear why do not hardcode AREATRIGGER_KELTHUZAD constant into the single place it used: boss_kelthuzad::JustSummoned
+                    pInstance->SetData(TYPE_SIGNAL_1, pAt->ID); //it is unclear why do not hardcode AREATRIGGER_KELTHUZAD constant into the single place it used: boss_kelthuzad::JustSummoned
 
                     if (pInstance->GetData(TYPE_KELTHUZAD) == NOT_STARTED)
                     {

--- a/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -171,7 +171,7 @@ struct boss_scarlet_commander_mograine : public CreatureScript
         void SpellHit(Unit* /*pWho*/, const SpellEntry* pSpell) override
         {
             // When hit with ressurection say text
-            if (pSpell->ID == SPELL_SCARLETRESURRECTION)
+            if (SD3_SpellId(pSpell) == SPELL_SCARLETRESURRECTION)
             {
                 DoScriptText(SAY_MO_RESSURECTED, m_creature);
                 m_bFakeDeath = false;

--- a/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
+++ b/scripts/eastern_kingdoms/scarlet_monastery/boss_mograine_and_whitemane.cpp
@@ -171,7 +171,7 @@ struct boss_scarlet_commander_mograine : public CreatureScript
         void SpellHit(Unit* /*pWho*/, const SpellEntry* pSpell) override
         {
             // When hit with ressurection say text
-            if (pSpell->Id == SPELL_SCARLETRESURRECTION)
+            if (pSpell->ID == SPELL_SCARLETRESURRECTION)
             {
                 DoScriptText(SAY_MO_RESSURECTED, m_creature);
                 m_bFakeDeath = false;

--- a/scripts/eastern_kingdoms/stranglethorn_vale.cpp
+++ b/scripts/eastern_kingdoms/stranglethorn_vale.cpp
@@ -68,7 +68,7 @@ struct mob_yenniku : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == SPELL_YENNIKUS_RELEASE && pCaster->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_YENNIKUS_RELEASE && pCaster->GetTypeId() == TYPEID_PLAYER)
             {
                 if (!m_uiResetTimer && ((Player*)pCaster)->GetQuestStatus(QUEST_ID_SAVING_YENNIKU) == QUEST_STATUS_INCOMPLETE)
                 {

--- a/scripts/eastern_kingdoms/stranglethorn_vale.cpp
+++ b/scripts/eastern_kingdoms/stranglethorn_vale.cpp
@@ -68,7 +68,7 @@ struct mob_yenniku : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_YENNIKUS_RELEASE && pCaster->GetTypeId() == TYPEID_PLAYER)
+            if (pSpell->ID == SPELL_YENNIKUS_RELEASE && pCaster->GetTypeId() == TYPEID_PLAYER)
             {
                 if (!m_uiResetTimer && ((Player*)pCaster)->GetQuestStatus(QUEST_ID_SAVING_YENNIKU) == QUEST_STATUS_INCOMPLETE)
                 {

--- a/scripts/eastern_kingdoms/stratholme/stratholme.cpp
+++ b/scripts/eastern_kingdoms/stratholme/stratholme.cpp
@@ -215,7 +215,7 @@ struct mob_restless_soul : public CreatureScript
         {
             if (pCaster->GetTypeId() == TYPEID_PLAYER)
             {
-                if (!m_bIsTagged && pSpell->Id == SPELL_EGAN_BLASTER && ((Player*)pCaster)->GetQuestStatus(QUEST_RESTLESS_SOUL) == QUEST_STATUS_INCOMPLETE)
+                if (!m_bIsTagged && pSpell->ID == SPELL_EGAN_BLASTER && ((Player*)pCaster)->GetQuestStatus(QUEST_RESTLESS_SOUL) == QUEST_STATUS_INCOMPLETE)
                 {
                     m_bIsTagged = true;
                     m_taggerGuid = pCaster->GetObjectGuid();
@@ -309,7 +309,7 @@ struct mobs_spectral_ghostly_citizen : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (!m_bIsTagged && pSpell->Id == SPELL_EGAN_BLASTER)
+            if (!m_bIsTagged && pSpell->ID == SPELL_EGAN_BLASTER)
             {
                 m_bIsTagged = true;
             }

--- a/scripts/eastern_kingdoms/stratholme/stratholme.cpp
+++ b/scripts/eastern_kingdoms/stratholme/stratholme.cpp
@@ -215,7 +215,7 @@ struct mob_restless_soul : public CreatureScript
         {
             if (pCaster->GetTypeId() == TYPEID_PLAYER)
             {
-                if (!m_bIsTagged && pSpell->ID == SPELL_EGAN_BLASTER && ((Player*)pCaster)->GetQuestStatus(QUEST_RESTLESS_SOUL) == QUEST_STATUS_INCOMPLETE)
+                if (!m_bIsTagged && SD3_SpellId(pSpell) == SPELL_EGAN_BLASTER && ((Player*)pCaster)->GetQuestStatus(QUEST_RESTLESS_SOUL) == QUEST_STATUS_INCOMPLETE)
                 {
                     m_bIsTagged = true;
                     m_taggerGuid = pCaster->GetObjectGuid();
@@ -309,7 +309,7 @@ struct mobs_spectral_ghostly_citizen : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (!m_bIsTagged && pSpell->ID == SPELL_EGAN_BLASTER)
+            if (!m_bIsTagged && SD3_SpellId(pSpell) == SPELL_EGAN_BLASTER)
             {
                 m_bIsTagged = true;
             }

--- a/scripts/eastern_kingdoms/zulgurub/boss_mandokir.cpp
+++ b/scripts/eastern_kingdoms/zulgurub/boss_mandokir.cpp
@@ -247,7 +247,7 @@ struct boss_mandokir : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_WATCH)
+            if (pSpell->ID == SPELL_WATCH)
             {
                 DoScriptText(SAY_WATCH, m_creature, pTarget);
                 DoScriptText(SAY_WATCH_WHISPER, m_creature, pTarget);

--- a/scripts/eastern_kingdoms/zulgurub/boss_mandokir.cpp
+++ b/scripts/eastern_kingdoms/zulgurub/boss_mandokir.cpp
@@ -247,7 +247,7 @@ struct boss_mandokir : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == SPELL_WATCH)
+            if (SD3_SpellId(pSpell) == SPELL_WATCH)
             {
                 DoScriptText(SAY_WATCH, m_creature, pTarget);
                 DoScriptText(SAY_WATCH_WHISPER, m_creature, pTarget);

--- a/scripts/eastern_kingdoms/zulgurub/instance_zulgurub.cpp
+++ b/scripts/eastern_kingdoms/zulgurub/instance_zulgurub.cpp
@@ -312,7 +312,7 @@ struct at_zulgurub : public AreaTriggerScript
 
     bool AreaTrigger_at_zulgurub(Player* pPlayer, AreaTriggerEntry const* pAt)
     {
-        if (pAt->id == AREATRIGGER_ENTER || pAt->id == AREATRIGGER_ALTAR)
+        if (pAt->ID == AREATRIGGER_ENTER || pAt->ID == AREATRIGGER_ALTAR)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {
@@ -321,7 +321,7 @@ struct at_zulgurub : public AreaTriggerScript
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())
             {
-                pInstance->SetData(TYPE_SIGNAL_1, pAt->id);
+                pInstance->SetData(TYPE_SIGNAL_1, pAt->ID);
             }
         }
 

--- a/scripts/eastern_kingdoms/zulgurub/instance_zulgurub.cpp
+++ b/scripts/eastern_kingdoms/zulgurub/instance_zulgurub.cpp
@@ -312,7 +312,7 @@ struct at_zulgurub : public AreaTriggerScript
 
     bool AreaTrigger_at_zulgurub(Player* pPlayer, AreaTriggerEntry const* pAt)
     {
-        if (pAt->ID == AREATRIGGER_ENTER || pAt->ID == AREATRIGGER_ALTAR)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_ENTER || SD3_AreaTriggerId(pAt) == AREATRIGGER_ALTAR)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {
@@ -321,7 +321,7 @@ struct at_zulgurub : public AreaTriggerScript
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())
             {
-                pInstance->SetData(TYPE_SIGNAL_1, pAt->ID);
+                pInstance->SetData(TYPE_SIGNAL_1, SD3_AreaTriggerId(pAt));
             }
         }
 

--- a/scripts/kalimdor/azshara.cpp
+++ b/scripts/kalimdor/azshara.cpp
@@ -134,7 +134,7 @@ struct npc_rizzle_sprysprocket : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == SPELL_SURRENDER)
+            if (SD3_SpellId(pSpell) == SPELL_SURRENDER)
             {
                 SetEscortPaused(true);
                 DoScriptText(SAY_END, m_creature);
@@ -145,7 +145,7 @@ struct npc_rizzle_sprysprocket : public CreatureScript
         // this may be wrong (and doesn't work)
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->ID == SPELL_FROST_GRENADE)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_FROST_GRENADE)
             {
                 DoScriptText(SAY_WHISPER_CHILL, m_creature, pTarget);
             }
@@ -380,7 +380,7 @@ struct mobs_spitelashes : public CreatureScript
 
             // Creature get polymorphed into a sheep and after 5 secs despawns
             if (pCaster->GetTypeId() == TYPEID_PLAYER && ((Player*)pCaster)->GetQuestStatus(QUEST_FRAGMENTED_MAGIC) == QUEST_STATUS_INCOMPLETE &&
-                (pSpell->ID == 118 || pSpell->ID == 12824 || pSpell->ID == 12825 || pSpell->ID == 12826))
+                (SD3_SpellId(pSpell) == 118 || SD3_SpellId(pSpell) == 12824 || SD3_SpellId(pSpell) == 12825 || SD3_SpellId(pSpell) == 12826))
             {
                 m_uiMorphTimer = 5000;
             }

--- a/scripts/kalimdor/azshara.cpp
+++ b/scripts/kalimdor/azshara.cpp
@@ -134,7 +134,7 @@ struct npc_rizzle_sprysprocket : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_SURRENDER)
+            if (pSpell->ID == SPELL_SURRENDER)
             {
                 SetEscortPaused(true);
                 DoScriptText(SAY_END, m_creature);
@@ -145,7 +145,7 @@ struct npc_rizzle_sprysprocket : public CreatureScript
         // this may be wrong (and doesn't work)
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_FROST_GRENADE)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->ID == SPELL_FROST_GRENADE)
             {
                 DoScriptText(SAY_WHISPER_CHILL, m_creature, pTarget);
             }
@@ -380,7 +380,7 @@ struct mobs_spitelashes : public CreatureScript
 
             // Creature get polymorphed into a sheep and after 5 secs despawns
             if (pCaster->GetTypeId() == TYPEID_PLAYER && ((Player*)pCaster)->GetQuestStatus(QUEST_FRAGMENTED_MAGIC) == QUEST_STATUS_INCOMPLETE &&
-                (pSpell->Id == 118 || pSpell->Id == 12824 || pSpell->Id == 12825 || pSpell->Id == 12826))
+                (pSpell->ID == 118 || pSpell->ID == 12824 || pSpell->ID == 12825 || pSpell->ID == 12826))
             {
                 m_uiMorphTimer = 5000;
             }

--- a/scripts/kalimdor/darkshore.cpp
+++ b/scripts/kalimdor/darkshore.cpp
@@ -119,7 +119,7 @@ struct npc_kerlonian : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->Id == SPELL_AWAKEN)
+            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->ID == SPELL_AWAKEN)
             {
                 ClearSleeping();
             }

--- a/scripts/kalimdor/darkshore.cpp
+++ b/scripts/kalimdor/darkshore.cpp
@@ -119,7 +119,7 @@ struct npc_kerlonian : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->ID == SPELL_AWAKEN)
+            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && SD3_SpellId(pSpell) == SPELL_AWAKEN)
             {
                 ClearSleeping();
             }

--- a/scripts/kalimdor/desolace.cpp
+++ b/scripts/kalimdor/desolace.cpp
@@ -104,7 +104,7 @@ struct npc_aged_dying_ancient_kodo : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, SpellEntry const* pSpell) override
         {
-            if (pSpell->Id == SPELL_KODO_KOMBO_GOSSIP)
+            if (pSpell->ID == SPELL_KODO_KOMBO_GOSSIP)
             {
                 m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 m_uiDespawnTimer = 60000;

--- a/scripts/kalimdor/desolace.cpp
+++ b/scripts/kalimdor/desolace.cpp
@@ -104,7 +104,7 @@ struct npc_aged_dying_ancient_kodo : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, SpellEntry const* pSpell) override
         {
-            if (pSpell->ID == SPELL_KODO_KOMBO_GOSSIP)
+            if (SD3_SpellId(pSpell) == SPELL_KODO_KOMBO_GOSSIP)
             {
                 m_creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 m_uiDespawnTimer = 60000;

--- a/scripts/kalimdor/onyxias_lair/boss_onyxia.cpp
+++ b/scripts/kalimdor/onyxias_lair/boss_onyxia.cpp
@@ -289,14 +289,14 @@ struct boss_onyxia : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_BREATH_EAST_TO_WEST ||
-                pSpell->Id == SPELL_BREATH_WEST_TO_EAST ||
-                pSpell->Id == SPELL_BREATH_SE_TO_NW ||
-                pSpell->Id == SPELL_BREATH_NW_TO_SE ||
-                pSpell->Id == SPELL_BREATH_SW_TO_NE ||
-                pSpell->Id == SPELL_BREATH_NE_TO_SW ||
-                pSpell->Id == SPELL_BREATH_SOUTH_TO_NORTH ||
-                pSpell->Id == SPELL_BREATH_NORTH_TO_SOUTH)
+            if (pSpell->ID == SPELL_BREATH_EAST_TO_WEST ||
+                pSpell->ID == SPELL_BREATH_WEST_TO_EAST ||
+                pSpell->ID == SPELL_BREATH_SE_TO_NW ||
+                pSpell->ID == SPELL_BREATH_NW_TO_SE ||
+                pSpell->ID == SPELL_BREATH_SW_TO_NE ||
+                pSpell->ID == SPELL_BREATH_NE_TO_SW ||
+                pSpell->ID == SPELL_BREATH_SOUTH_TO_NORTH ||
+                pSpell->ID == SPELL_BREATH_NORTH_TO_SOUTH)
             {
                 // This was sent with SendMonsterMove - which resulted in better speed than now
                 m_creature->GetMotionMaster()->MovePoint(m_uiMovePoint, aMoveData[m_uiMovePoint].fX, aMoveData[m_uiMovePoint].fY, aMoveData[m_uiMovePoint].fZ);

--- a/scripts/kalimdor/onyxias_lair/boss_onyxia.cpp
+++ b/scripts/kalimdor/onyxias_lair/boss_onyxia.cpp
@@ -289,14 +289,14 @@ struct boss_onyxia : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == SPELL_BREATH_EAST_TO_WEST ||
-                pSpell->ID == SPELL_BREATH_WEST_TO_EAST ||
-                pSpell->ID == SPELL_BREATH_SE_TO_NW ||
-                pSpell->ID == SPELL_BREATH_NW_TO_SE ||
-                pSpell->ID == SPELL_BREATH_SW_TO_NE ||
-                pSpell->ID == SPELL_BREATH_NE_TO_SW ||
-                pSpell->ID == SPELL_BREATH_SOUTH_TO_NORTH ||
-                pSpell->ID == SPELL_BREATH_NORTH_TO_SOUTH)
+            if (SD3_SpellId(pSpell) == SPELL_BREATH_EAST_TO_WEST ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_WEST_TO_EAST ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_SE_TO_NW ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_NW_TO_SE ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_SW_TO_NE ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_NE_TO_SW ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_SOUTH_TO_NORTH ||
+                SD3_SpellId(pSpell) == SPELL_BREATH_NORTH_TO_SOUTH)
             {
                 // This was sent with SendMonsterMove - which resulted in better speed than now
                 m_creature->GetMotionMaster()->MovePoint(m_uiMovePoint, aMoveData[m_uiMovePoint].fX, aMoveData[m_uiMovePoint].fY, aMoveData[m_uiMovePoint].fZ);

--- a/scripts/kalimdor/ruins_of_ahnqiraj/boss_ossirian.cpp
+++ b/scripts/kalimdor/ruins_of_ahnqiraj/boss_ossirian.cpp
@@ -192,7 +192,7 @@ struct boss_ossirian : public CreatureScript
                 bool bIsWeaknessSpell = false;
                 for (uint8 i = 0; i < countof(aWeaknessSpell); ++i)
                 {
-                    if (pSpell->ID == aWeaknessSpell[i])
+                    if (SD3_SpellId(pSpell) == aWeaknessSpell[i])
                     {
                         bIsWeaknessSpell = true;
                         break;

--- a/scripts/kalimdor/ruins_of_ahnqiraj/boss_ossirian.cpp
+++ b/scripts/kalimdor/ruins_of_ahnqiraj/boss_ossirian.cpp
@@ -192,7 +192,7 @@ struct boss_ossirian : public CreatureScript
                 bool bIsWeaknessSpell = false;
                 for (uint8 i = 0; i < countof(aWeaknessSpell); ++i)
                 {
-                    if (pSpell->Id == aWeaknessSpell[i])
+                    if (pSpell->ID == aWeaknessSpell[i])
                     {
                         bIsWeaknessSpell = true;
                         break;

--- a/scripts/kalimdor/silithus.cpp
+++ b/scripts/kalimdor/silithus.cpp
@@ -976,7 +976,7 @@ struct npc_solenor_the_slayer : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
 
-            if (pSpell && pSpell->Id == 14268)   // Wing Clip (Rank 3)
+            if (pSpell && pSpell->ID == 14268)   // Wing Clip (Rank 3)
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_CRIPPLING_CLIP, CAST_TRIGGERED) == CAST_OK)
                 {

--- a/scripts/kalimdor/silithus.cpp
+++ b/scripts/kalimdor/silithus.cpp
@@ -976,7 +976,7 @@ struct npc_solenor_the_slayer : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
 
-            if (pSpell && pSpell->ID == 14268)   // Wing Clip (Rank 3)
+            if (pSpell && SD3_SpellId(pSpell) == 14268)   // Wing Clip (Rank 3)
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_CRIPPLING_CLIP, CAST_TRIGGERED) == CAST_OK)
                 {

--- a/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
@@ -926,7 +926,7 @@ struct at_stomach_cthun : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->ID == AREATRIGGER_STOMACH_1)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_STOMACH_1)
         {
             if (pPlayer->isGameMaster() || !pPlayer->IsAlive())
             {

--- a/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/boss_cthun.cpp
@@ -926,7 +926,7 @@ struct at_stomach_cthun : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->id == AREATRIGGER_STOMACH_1)
+        if (pAt->ID == AREATRIGGER_STOMACH_1)
         {
             if (pPlayer->isGameMaster() || !pPlayer->IsAlive())
             {

--- a/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
@@ -162,7 +162,7 @@ struct boss_twin_emperorsAI : public ScriptedAI
 
     void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
     {
-        if (pSpell->Id == SPELL_TWIN_TELEPORT)
+        if (pSpell->ID == SPELL_TWIN_TELEPORT)
         {
             DoTeleportAbility();
             DoResetThreat();

--- a/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/boss_twinemperors.cpp
@@ -162,7 +162,7 @@ struct boss_twin_emperorsAI : public ScriptedAI
 
     void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
     {
-        if (pSpell->ID == SPELL_TWIN_TELEPORT)
+        if (SD3_SpellId(pSpell) == SPELL_TWIN_TELEPORT)
         {
             DoTeleportAbility();
             DoResetThreat();

--- a/scripts/kalimdor/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
@@ -380,16 +380,16 @@ struct at_temple_ahnqiraj : public AreaTriggerScript
             return false;
         }
 
-        if (pAt->ID == AREATRIGGER_TWIN_EMPERORS)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_TWIN_EMPERORS)
         {
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())
             {
-                pInstance->SetData(TYPE_SIGNAL, pAt->ID);
+                pInstance->SetData(TYPE_SIGNAL, SD3_AreaTriggerId(pAt));
             }
         }
 
-        if (pAt->ID == AREATRIGGER_SARTURA)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_SARTURA)
         {
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())

--- a/scripts/kalimdor/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
+++ b/scripts/kalimdor/temple_of_ahnqiraj/instance_temple_of_ahnqiraj.cpp
@@ -380,16 +380,16 @@ struct at_temple_ahnqiraj : public AreaTriggerScript
             return false;
         }
 
-        if (pAt->id == AREATRIGGER_TWIN_EMPERORS)
+        if (pAt->ID == AREATRIGGER_TWIN_EMPERORS)
         {
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())
             {
-                pInstance->SetData(TYPE_SIGNAL, pAt->id);
+                pInstance->SetData(TYPE_SIGNAL, pAt->ID);
             }
         }
 
-        if (pAt->id == AREATRIGGER_SARTURA)
+        if (pAt->ID == AREATRIGGER_SARTURA)
         {
 
             if (ScriptedInstance* pInstance = (ScriptedInstance*)pPlayer->GetInstanceData())

--- a/scripts/kalimdor/the_barrens.cpp
+++ b/scripts/kalimdor/the_barrens.cpp
@@ -256,7 +256,7 @@ struct npc_taskmaster_fizzule : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pCaster->GetTypeId() == TYPEID_PLAYER && (pSpell->Id == SPELL_FLARE || pSpell->Id == SPELL_FOLLY))
+            if (pCaster->GetTypeId() == TYPEID_PLAYER && (pSpell->ID == SPELL_FLARE || pSpell->ID == SPELL_FOLLY))
             {
                 ++m_uiFlareCount;
 

--- a/scripts/kalimdor/the_barrens.cpp
+++ b/scripts/kalimdor/the_barrens.cpp
@@ -256,7 +256,7 @@ struct npc_taskmaster_fizzule : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pCaster->GetTypeId() == TYPEID_PLAYER && (pSpell->ID == SPELL_FLARE || pSpell->ID == SPELL_FOLLY))
+            if (pCaster->GetTypeId() == TYPEID_PLAYER && (SD3_SpellId(pSpell) == SPELL_FLARE || SD3_SpellId(pSpell) == SPELL_FOLLY))
             {
                 ++m_uiFlareCount;
 

--- a/scripts/kalimdor/ungoro_crater.cpp
+++ b/scripts/kalimdor/ungoro_crater.cpp
@@ -226,7 +226,7 @@ struct npc_ringo : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->ID == SPELL_REVIVE_RINGO)
+            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && SD3_SpellId(pSpell) == SPELL_REVIVE_RINGO)
             {
                 ClearFaint();
             }
@@ -666,7 +666,7 @@ struct npc_simone_the_seductressAI : public ScriptedAI
 
     void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
     {
-        if (pSpell && pSpell->ID == 14280)   // Viper Sting (Rank 3)
+        if (pSpell && SD3_SpellId(pSpell) == 14280)   // Viper Sting (Rank 3)
         {
             if (DoCastSpellIfCan(m_creature, SPELL_SILENCE, CAST_TRIGGERED) == CAST_OK)
             {

--- a/scripts/kalimdor/ungoro_crater.cpp
+++ b/scripts/kalimdor/ungoro_crater.cpp
@@ -226,7 +226,7 @@ struct npc_ringo : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->Id == SPELL_REVIVE_RINGO)
+            if (HasFollowState(STATE_FOLLOW_INPROGRESS | STATE_FOLLOW_PAUSED) && pSpell->ID == SPELL_REVIVE_RINGO)
             {
                 ClearFaint();
             }
@@ -666,7 +666,7 @@ struct npc_simone_the_seductressAI : public ScriptedAI
 
     void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
     {
-        if (pSpell && pSpell->Id == 14280)   // Viper Sting (Rank 3)
+        if (pSpell && pSpell->ID == 14280)   // Viper Sting (Rank 3)
         {
             if (DoCastSpellIfCan(m_creature, SPELL_SILENCE, CAST_TRIGGERED) == CAST_OK)
             {

--- a/scripts/kalimdor/winterspring.cpp
+++ b/scripts/kalimdor/winterspring.cpp
@@ -704,7 +704,7 @@ struct npc_artorius_the_doombringer : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == 13555 || pSpell->ID == 25295)             // Serpent Sting (Rank 8 or Rank 9)
+            if (SD3_SpellId(pSpell) == 13555 || SD3_SpellId(pSpell) == 25295)             // Serpent Sting (Rank 8 or Rank 9)
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_STINGING_TRAUMA, CAST_TRIGGERED) == CAST_OK)
                 {

--- a/scripts/kalimdor/winterspring.cpp
+++ b/scripts/kalimdor/winterspring.cpp
@@ -704,7 +704,7 @@ struct npc_artorius_the_doombringer : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == 13555 || pSpell->Id == 25295)             // Serpent Sting (Rank 8 or Rank 9)
+            if (pSpell->ID == 13555 || pSpell->ID == 25295)             // Serpent Sting (Rank 8 or Rank 9)
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_STINGING_TRAUMA, CAST_TRIGGERED) == CAST_OK)
                 {

--- a/scripts/kalimdor/zulfarrak/zulfarrak.cpp
+++ b/scripts/kalimdor/zulfarrak/zulfarrak.cpp
@@ -113,7 +113,7 @@ struct at_zulfarrak : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->id == AREATRIGGER_ANTUSUL)
+        if (pAt->ID == AREATRIGGER_ANTUSUL)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {

--- a/scripts/kalimdor/zulfarrak/zulfarrak.cpp
+++ b/scripts/kalimdor/zulfarrak/zulfarrak.cpp
@@ -113,7 +113,7 @@ struct at_zulfarrak : public AreaTriggerScript
 
     bool OnTrigger(Player* pPlayer, AreaTriggerEntry const* pAt) override
     {
-        if (pAt->ID == AREATRIGGER_ANTUSUL)
+        if (SD3_AreaTriggerId(pAt) == AREATRIGGER_ANTUSUL)
         {
             if (pPlayer->isGameMaster() || pPlayer->IsDead())
             {

--- a/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_deathbringer_saurfang.cpp
+++ b/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_deathbringer_saurfang.cpp
@@ -132,11 +132,7 @@ struct boss_deathbringer_saurfang : public CreatureScript
         boss_deathbringer_saurfangAI(Creature* pCreature) : ScriptedAI(pCreature)
         {
             m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
-#if !defined(MISTS)
-            m_powerBloodPower = m_creature->powerType;
-#else
             m_powerBloodPower = m_creature->GetPowerType();
-#endif
             m_bIsIntroDone = false;
         }
 

--- a/scripts/world/areatrigger_scripts.cpp
+++ b/scripts/world/areatrigger_scripts.cpp
@@ -71,7 +71,7 @@ struct at_childrens_week_spot : public AreaTriggerScript
     {
         for (uint8 i = 0; i < 6; ++i)
         {
-            if (pAt->ID == TriggerOrphanSpell[i][0] &&
+            if (SD3_AreaTriggerId(pAt) == TriggerOrphanSpell[i][0] &&
                 pPlayer->GetMiniPet() && pPlayer->GetMiniPet()->GetEntry() == TriggerOrphanSpell[i][1])
             {
                 pPlayer->CastSpell(pPlayer, TriggerOrphanSpell[i][2], true);

--- a/scripts/world/areatrigger_scripts.cpp
+++ b/scripts/world/areatrigger_scripts.cpp
@@ -71,7 +71,7 @@ struct at_childrens_week_spot : public AreaTriggerScript
     {
         for (uint8 i = 0; i < 6; ++i)
         {
-            if (pAt->id == TriggerOrphanSpell[i][0] &&
+            if (pAt->ID == TriggerOrphanSpell[i][0] &&
                 pPlayer->GetMiniPet() && pPlayer->GetMiniPet()->GetEntry() == TriggerOrphanSpell[i][1])
             {
                 pPlayer->CastSpell(pPlayer, TriggerOrphanSpell[i][2], true);

--- a/scripts/world/bosses_emerald_dragons.cpp
+++ b/scripts/world/bosses_emerald_dragons.cpp
@@ -315,7 +315,7 @@ struct boss_lethon : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Summon a shade for each player hit
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->ID == SPELL_DRAW_SPIRIT)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_DRAW_SPIRIT)
             {
                 // Summon this way, to be able to cast the shade visual spell with player as original caster
                 // This might not be supported currently by core, but this spell's visual should be dependend on the player

--- a/scripts/world/bosses_emerald_dragons.cpp
+++ b/scripts/world/bosses_emerald_dragons.cpp
@@ -315,7 +315,7 @@ struct boss_lethon : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Summon a shade for each player hit
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_DRAW_SPIRIT)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->ID == SPELL_DRAW_SPIRIT)
             {
                 // Summon this way, to be able to cast the shade visual spell with player as original caster
                 // This might not be supported currently by core, but this spell's visual should be dependend on the player

--- a/scripts/world/npcs_special.cpp
+++ b/scripts/world/npcs_special.cpp
@@ -829,7 +829,7 @@ struct npc_injured_patient : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pCaster->GetTypeId() == TYPEID_PLAYER && m_creature->IsAlive() && pSpell->Id == 20804)
+            if (pCaster->GetTypeId() == TYPEID_PLAYER && m_creature->IsAlive() && pSpell->ID == 20804)
             {
                 Player* pPlayer = static_cast<Player*>(pCaster);
                 if (pPlayer->GetQuestStatus(6624) == QUEST_STATUS_INCOMPLETE || pPlayer->GetQuestStatus(6622) == QUEST_STATUS_INCOMPLETE)
@@ -1001,7 +1001,7 @@ struct npc_garments_of_quests : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_LESSER_HEAL_R2 || pSpell->Id == SPELL_FORTITUDE_R1)
+            if (pSpell->ID == SPELL_LESSER_HEAL_R2 || pSpell->ID == SPELL_FORTITUDE_R1)
             {
                 // not while in combat
                 if (m_creature->IsInCombat())
@@ -1022,12 +1022,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_SHAYA:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_MOON) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->Id == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_SHAYA_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->Id == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1039,12 +1039,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_ROBERTS:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_LIGHT_1) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->Id == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_ROBERTS_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->Id == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1056,12 +1056,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_DOLF:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_LIGHT_2) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->Id == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_DOLF_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->Id == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1073,12 +1073,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_KORJA:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_SPIRIT) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->Id == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_KORJA_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->Id == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1090,12 +1090,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_DG_KEL:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_DARKNESS) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->Id == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_DG_KEL_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->Id == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1730,11 +1730,11 @@ struct npc_burster_worm : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if ((pSpell->Id == SPELL_TUNNEL_BORE || pSpell->Id == SPELL_BONE_BORE) && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if ((pSpell->ID == SPELL_TUNNEL_BORE || pSpell->ID == SPELL_BONE_BORE) && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 // remove auras straight on spell hit
                 m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                m_creature->RemoveAurasDueToSpell(pSpell->Id == SPELL_TUNNEL_BORE ? SPELL_TUNNEL_BORE_PASSIVE : SPELL_TUNNEL_BORE_BONE_PASSIVE);
+                m_creature->RemoveAurasDueToSpell(pSpell->ID == SPELL_TUNNEL_BORE ? SPELL_TUNNEL_BORE_PASSIVE : SPELL_TUNNEL_BORE_BONE_PASSIVE);
                 m_creature->RemoveAurasDueToSpell(SPELL_SANDWORM_SUBMERGE_VISUAL);
 
                 AttackStart(pTarget);

--- a/scripts/world/npcs_special.cpp
+++ b/scripts/world/npcs_special.cpp
@@ -829,7 +829,7 @@ struct npc_injured_patient : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pCaster->GetTypeId() == TYPEID_PLAYER && m_creature->IsAlive() && pSpell->ID == 20804)
+            if (pCaster->GetTypeId() == TYPEID_PLAYER && m_creature->IsAlive() && SD3_SpellId(pSpell) == 20804)
             {
                 Player* pPlayer = static_cast<Player*>(pCaster);
                 if (pPlayer->GetQuestStatus(6624) == QUEST_STATUS_INCOMPLETE || pPlayer->GetQuestStatus(6622) == QUEST_STATUS_INCOMPLETE)
@@ -1001,7 +1001,7 @@ struct npc_garments_of_quests : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->ID == SPELL_LESSER_HEAL_R2 || pSpell->ID == SPELL_FORTITUDE_R1)
+            if (SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2 || SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
             {
                 // not while in combat
                 if (m_creature->IsInCombat())
@@ -1022,12 +1022,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_SHAYA:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_MOON) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_SHAYA_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1039,12 +1039,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_ROBERTS:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_LIGHT_1) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_ROBERTS_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1056,12 +1056,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_DOLF:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_LIGHT_2) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_DOLF_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1073,12 +1073,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_KORJA:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_SPIRIT) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_KORJA_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1090,12 +1090,12 @@ struct npc_garments_of_quests : public CreatureScript
                         case ENTRY_DG_KEL:
                             if (((Player*)pCaster)->GetQuestStatus(QUEST_DARKNESS) == QUEST_STATUS_INCOMPLETE)
                             {
-                                if (m_bIsHealed && !m_bCanRun && pSpell->ID == SPELL_FORTITUDE_R1)
+                                if (m_bIsHealed && !m_bCanRun && SD3_SpellId(pSpell) == SPELL_FORTITUDE_R1)
                                 {
                                     DoScriptText(SAY_DG_KEL_THANKS, m_creature, pCaster);
                                     m_bCanRun = true;
                                 }
-                                else if (!m_bIsHealed && pSpell->ID == SPELL_LESSER_HEAL_R2)
+                                else if (!m_bIsHealed && SD3_SpellId(pSpell) == SPELL_LESSER_HEAL_R2)
                                 {
                                     m_playerGuid = pCaster->GetObjectGuid();
                                     m_creature->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1730,11 +1730,11 @@ struct npc_burster_worm : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if ((pSpell->ID == SPELL_TUNNEL_BORE || pSpell->ID == SPELL_BONE_BORE) && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if ((SD3_SpellId(pSpell) == SPELL_TUNNEL_BORE || SD3_SpellId(pSpell) == SPELL_BONE_BORE) && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 // remove auras straight on spell hit
                 m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                m_creature->RemoveAurasDueToSpell(pSpell->ID == SPELL_TUNNEL_BORE ? SPELL_TUNNEL_BORE_PASSIVE : SPELL_TUNNEL_BORE_BONE_PASSIVE);
+                m_creature->RemoveAurasDueToSpell(SD3_SpellId(pSpell) == SPELL_TUNNEL_BORE ? SPELL_TUNNEL_BORE_PASSIVE : SPELL_TUNNEL_BORE_BONE_PASSIVE);
                 m_creature->RemoveAurasDueToSpell(SPELL_SANDWORM_SUBMERGE_VISUAL);
 
                 AttackStart(pTarget);

--- a/system/ScriptDevMgr.cpp
+++ b/system/ScriptDevMgr.cpp
@@ -637,7 +637,7 @@ bool SD3::GOQuestRewarded(Player* pPlayer, GameObject* pGo, Quest const* pQuest)
  */
 bool SD3::AreaTrigger(Player* pPlayer, AreaTriggerEntry const* atEntry)
 {
-    Script* pTempScript = m_scripts[sScriptMgr.GetBoundScriptId(SCRIPTED_AREATRIGGER, atEntry->id)];
+    Script* pTempScript = m_scripts[sScriptMgr.GetBoundScriptId(SCRIPTED_AREATRIGGER, atEntry->ID)];
 
     if (!pTempScript || !pTempScript->ToAreaTriggerScript())
     {

--- a/system/ScriptDevMgr.cpp
+++ b/system/ScriptDevMgr.cpp
@@ -637,7 +637,7 @@ bool SD3::GOQuestRewarded(Player* pPlayer, GameObject* pGo, Quest const* pQuest)
  */
 bool SD3::AreaTrigger(Player* pPlayer, AreaTriggerEntry const* atEntry)
 {
-    Script* pTempScript = m_scripts[sScriptMgr.GetBoundScriptId(SCRIPTED_AREATRIGGER, atEntry->ID)];
+    Script* pTempScript = m_scripts[sScriptMgr.GetBoundScriptId(SCRIPTED_AREATRIGGER, SD3_AreaTriggerId(atEntry))];
 
     if (!pTempScript || !pTempScript->ToAreaTriggerScript())
     {


### PR DESCRIPTION
## Expansion-guarded accessors for mangos-zero's DBC alignment (+ a cross-core `GetPowerType()` fix)

mangos-zero is aligning its core `DBCStructure.h` field names to the client-verified 1.12 `.dbd` schema (e.g. `Id→ID`, `minRange→RangeMin`, `id→ID` on `AreaTriggerEntry`). Because ScriptDev3 is **shared by all five getMangos cores**, those zero-only renames cannot be applied unconditionally to shared SD3 code — the other cores keep the legacy names. This PR routes the affected accesses through **expansion-guarded accessors** so the shared code compiles unchanged on every core.

### What's in here

- **New inline accessors in `include/sc_creature.h`**, each resolving per expansion:
  - `SD3_SpellId`, `SD3_SpellManaCost`, `SD3_SpellPowerType`, `SD3_SpellRangeIndex` — `CLASSIC` → the new `.dbd` name, `CATA`/`MISTS` → the existing `GetXxx()` methods, `TBC`/`WOTLK` → the legacy field.
  - `SD3_SpellEffectImplicitTargetA` / `SD3_SpellEffectApplyAuraName` — fenced `#if !defined(CATA) && !defined(MISTS)` (those cores expose `GetEffect*ByIndex()` instead).
  - `SD3_AreaTriggerId`, `SD3_SpellRangeMin`, `SD3_SpellRangeMax` — `CLASSIC` → new name, `#else` → legacy.
- **Consumers routed through them** — the boss/AreaTrigger scripts and `system/ScriptDevMgr.cpp` that previously read `pSpell->Id`, `pAt->id`, `pRange->minRange`, etc.

This extends SD3's existing cross-core pattern (`GetManaCost()`/`GetPowerType()`), so **no behaviour changes on any core** — each core only ever compiles its own branch of each accessor.

### Bonus: fixes a cross-core regression in `boss_shade_of_aran` / `boss_deathbringer_saurfang`

While compile-checking this against every core, we found that commit `005a340f` had changed a working `m_creature->GetPowerType()` call to `#if !defined(MISTS) m_creature->powerType #else GetPowerType() #endif`. That assumes every core except MoP has a `Creature::powerType` **data member** — but only Classic does; TBC/WotLK/Cata expose only `GetPowerType()`. So `mangosscript` fails to compile on TBC/WotLK/Cata (`'powerType' is not a member of 'Creature'`). This PR reverts both sites to plain `m_creature->GetPowerType()` (present on all cores; behaviourally identical), matching every fork-pinned SD3 pointer that predates the regression.

### Verification

Real `mangosscript` compiles with this branch dropped into fresh core checkouts:

| Core | Result |
|------|--------|
| Classic | `mangosscript.lib` links, 0 errors |
| TBC | `mangosscript.lib` links, 0 errors |
| WotLK | `mangosscript.lib` links, 0 errors |
| Cata | `mangosscript.lib` links, 0 errors |

(Before the `GetPowerType()` fix, TBC/WotLK/Cata failed to link on the pre-existing `powerType` errors.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/97)
<!-- Reviewable:end -->
