### PR TITLE
TBC: expansion-guard Spell/AreaTable/SpellRange accessors + route TBC-content Spell.Id (mangos-one DBC alignment)

### DIFF
--- a/include/sc_creature.h
+++ b/include/sc_creature.h
@@ -124,6 +124,8 @@ inline float SD3_SpellRangeMin(SpellRangeEntry const* pRange)
 {
 #if defined (CLASSIC)
     return pRange->RangeMin;
+#elif defined (TBC)
+    return pRange->RangeMin;
 #else
     return pRange->minRange;
 #endif
@@ -132,6 +134,8 @@ inline float SD3_SpellRangeMin(SpellRangeEntry const* pRange)
 inline float SD3_SpellRangeMax(SpellRangeEntry const* pRange)
 {
 #if defined (CLASSIC)
+    return pRange->RangeMax;
+#elif defined (TBC)
     return pRange->RangeMax;
 #else
     return pRange->maxRange;

--- a/include/sc_creature.h
+++ b/include/sc_creature.h
@@ -44,6 +44,8 @@ inline uint32 SD3_SpellId(SpellEntry const* pSpell)
 {
 #if defined (CLASSIC)
     return pSpell->ID;
+#elif defined (TBC)
+    return pSpell->ID;
 #else
     return pSpell->Id;
 #endif
@@ -55,7 +57,9 @@ inline uint32 SD3_SpellManaCost(SpellEntry const* pSpell)
     return pSpell->GetManaCost();
 #elif defined (CLASSIC)
     return pSpell->ManaCost;
-#else   // TBC, WOTLK
+#elif defined (TBC)
+    return pSpell->ManaCost;
+#else   // WOTLK
     return pSpell->manaCost;
 #endif
 }
@@ -66,7 +70,9 @@ inline uint32 SD3_SpellPowerType(SpellEntry const* pSpell)
     return pSpell->GetPowerType();
 #elif defined (CLASSIC)
     return pSpell->PowerType;
-#else   // TBC, WOTLK, CATA
+#elif defined (TBC)
+    return pSpell->PowerType;
+#else   // WOTLK, CATA
     return pSpell->powerType;
 #endif
 }
@@ -77,7 +83,9 @@ inline uint32 SD3_SpellRangeIndex(SpellEntry const* pSpell)
     return pSpell->GetRangeIndex();
 #elif defined (CLASSIC)
     return pSpell->RangeIndex;
-#else   // TBC, WOTLK, CATA
+#elif defined (TBC)
+    return pSpell->RangeIndex;
+#else   // WOTLK, CATA
     return pSpell->rangeIndex;
 #endif
 }
@@ -92,7 +100,9 @@ inline uint32 SD3_SpellEffectImplicitTargetA(SpellEntry const* pSpell, uint8 ind
 {
 #if defined (CLASSIC)
     return pSpell->ImplicitTargetA[index];
-#else   // TBC, WOTLK
+#elif defined (TBC)
+    return pSpell->ImplicitTargetA[index];
+#else   // WOTLK
     return pSpell->EffectImplicitTargetA[index];
 #endif
 }
@@ -101,7 +111,9 @@ inline uint32 SD3_SpellEffectApplyAuraName(SpellEntry const* pSpell, uint8 index
 {
 #if defined (CLASSIC)
     return pSpell->EffectAura[index];
-#else   // TBC, WOTLK
+#elif defined (TBC)
+    return pSpell->EffectAura[index];
+#else   // WOTLK
     return pSpell->EffectApplyAuraName[index];
 #endif
 }

--- a/scripts/battlegrounds/battleground.cpp
+++ b/scripts/battlegrounds/battleground.cpp
@@ -161,7 +161,7 @@ struct npc_spirit_guide : public CreatureScript
          */
         void SpellHitTarget(Unit* pUnit, const SpellEntry* pSpellEntry) override
         {
-            if (pSpellEntry->Id == SPELL_SPIRIT_HEAL && pUnit->GetTypeId() == TYPEID_PLAYER &&
+            if (SD3_SpellId(pSpellEntry) == SPELL_SPIRIT_HEAL && pUnit->GetTypeId() == TYPEID_PLAYER &&
                 pUnit->HasAura(SPELL_WAITING_TO_RESURRECT))
             {
                 pUnit->CastSpell(pUnit, SPELL_SPIRIT_HEAL_MANA, true);

--- a/scripts/eastern_kingdoms/karazhan/boss_prince_malchezaar.cpp
+++ b/scripts/eastern_kingdoms/karazhan/boss_prince_malchezaar.cpp
@@ -192,7 +192,7 @@ struct boss_malchezaar : public CreatureScript
         void SpellHitTarget(Unit* pTarget, SpellEntry const* pSpellEntry) override
         {
             // Target selection is already handled properly in core (doesn't affect tank)
-            if (pSpellEntry->Id == SPELL_ENFEEBLE && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpellEntry) == SPELL_ENFEEBLE && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 // Workaround to handle health set to 1
                 m_aEnfeebleTargetGuid[m_uiEnfeebleIndex] = pTarget->GetObjectGuid();

--- a/scripts/eastern_kingdoms/karazhan/bosses_opera.cpp
+++ b/scripts/eastern_kingdoms/karazhan/bosses_opera.cpp
@@ -1362,7 +1362,7 @@ struct boss_romulo : public CreatureScript
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
             // remove fake death on res
-            if (pSpell->Id == SPELL_UNDYING_LOVE && pCaster->GetEntry() == NPC_JULIANNE)
+            if (SD3_SpellId(pSpell) == SPELL_UNDYING_LOVE && pCaster->GetEntry() == NPC_JULIANNE)
             {
                 DoRemoveFakeDeath();
             }

--- a/scripts/eastern_kingdoms/karazhan/chess_event.cpp
+++ b/scripts/eastern_kingdoms/karazhan/chess_event.cpp
@@ -457,7 +457,7 @@ struct npc_chess_piece_genericAI : public ScriptedAI
     void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
     {
         // do a soft reset when the piece is controlled
-        if (pCaster->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_CONTROL_PIECE)
+        if (pCaster->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_CONTROL_PIECE)
         {
             Reset();
         }

--- a/scripts/eastern_kingdoms/karazhan/karazhan.cpp
+++ b/scripts/eastern_kingdoms/karazhan/karazhan.cpp
@@ -450,7 +450,7 @@ struct npc_image_of_medivh : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_FIREBALL_REFLECT && pCaster->GetEntry() == NPC_IMAGE_OF_ARCANAGOS)
+            if (SD3_SpellId(pSpell) == SPELL_FIREBALL_REFLECT && pCaster->GetEntry() == NPC_IMAGE_OF_ARCANAGOS)
             {
                 StartNextDialogueText(SPELL_MANA_SHIELD);
                 DoCastSpellIfCan(m_creature, SPELL_MANA_SHIELD);
@@ -517,7 +517,7 @@ struct npc_image_arcanagos : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_FIREBALL && pCaster->GetEntry() == NPC_IMAGE_OF_MEDIVH)
+            if (SD3_SpellId(pSpell) == SPELL_FIREBALL && pCaster->GetEntry() == NPC_IMAGE_OF_MEDIVH)
             {
                 // !!!Workaround Alert!!! - the spell should be cast on Medivh without changing the unit flags!
                 pCaster->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);

--- a/scripts/eastern_kingdoms/magisters_terrace/boss_felblood_kaelthas.cpp
+++ b/scripts/eastern_kingdoms/magisters_terrace/boss_felblood_kaelthas.cpp
@@ -293,7 +293,7 @@ struct boss_felblood_kaelthas : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Handle Gravity Lapse on targets
-            if (pSpell->Id == SPELL_GRAVITY_LAPSE && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_GRAVITY_LAPSE && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 DoCastSpellIfCan(pTarget, aGravityLapseSpells[m_uiGravityIndex], CAST_TRIGGERED);
                 pTarget->CastSpell(pTarget, SPELL_GRAVITY_LAPSE_FLY, true, 0, 0, m_creature->GetObjectGuid());

--- a/scripts/eastern_kingdoms/scarlet_monastery/boss_headless_horseman.cpp
+++ b/scripts/eastern_kingdoms/scarlet_monastery/boss_headless_horseman.cpp
@@ -202,7 +202,7 @@ struct boss_headless_horseman : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_HORSEMAN_SUMMON)
+            if (SD3_SpellId(pSpell) == SPELL_HORSEMAN_SUMMON)
             {
                 DoScriptText(SAY_SPROUTING_PUMPKINS, m_creature);
             }

--- a/scripts/eastern_kingdoms/sunwell_plateau/boss_brutallus.cpp
+++ b/scripts/eastern_kingdoms/sunwell_plateau/boss_brutallus.cpp
@@ -279,7 +279,7 @@ struct boss_brutallus : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Fake death Madrigosa when charged
-            if (pTarget->GetEntry() == NPC_MADRIGOSA && pSpell->Id == SPELL_CHARGE)
+            if (pTarget->GetEntry() == NPC_MADRIGOSA && SD3_SpellId(pSpell) == SPELL_CHARGE)
             {
                 DoScriptText(YELL_MADR_DEATH, pTarget);
                 pTarget->InterruptNonMeleeSpells(true);

--- a/scripts/eastern_kingdoms/sunwell_plateau/boss_felmyst.cpp
+++ b/scripts/eastern_kingdoms/sunwell_plateau/boss_felmyst.cpp
@@ -330,7 +330,7 @@ struct boss_felmyst : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_ENCAPSULATE_CHANNEL)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_ENCAPSULATE_CHANNEL)
             {
                 pTarget->CastSpell(pTarget, SPELL_ENCAPSULATE, true, nullptr, nullptr, m_creature->GetObjectGuid());
             }

--- a/scripts/eastern_kingdoms/sunwell_plateau/boss_muru.cpp
+++ b/scripts/eastern_kingdoms/sunwell_plateau/boss_muru.cpp
@@ -436,7 +436,7 @@ struct npc_portal_target : public CreatureScript
         {
             // These spells are dummies, but are used only to init the timers
             // They could use the EffectDummyCreature to handle this, but this makes code easier
-            switch (pSpell->Id)
+            switch (SD3_SpellId(pSpell))
             {
                 // Init sentinel summon timer
                 case SPELL_OPEN_PORTAL:

--- a/scripts/eastern_kingdoms/zulaman/boss_halazzi.cpp
+++ b/scripts/eastern_kingdoms/zulaman/boss_halazzi.cpp
@@ -186,7 +186,7 @@ struct boss_halazzi : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_TRANSFIGURE_TRANSFORM)
+            if (SD3_SpellId(pSpell) == SPELL_TRANSFIGURE_TRANSFORM)
             {
                 DoCastSpellIfCan(m_creature, SPELL_HALAZZI_TRANSFORM_SUMMON, CAST_TRIGGERED);
                 m_creature->UpdateEntry(NPC_HALAZZI_TROLL);

--- a/scripts/eastern_kingdoms/zulaman/boss_janalai.cpp
+++ b/scripts/eastern_kingdoms/zulaman/boss_janalai.cpp
@@ -514,7 +514,7 @@ struct npc_amanishi_hatcher : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, SpellEntry const* pSpell) override
         {
-            if ((pSpell->Id != SPELL_HATCH_EGG_1 && pSpell->Id != SPELL_HATCH_EGG_2) || pTarget->GetEntry() != NPC_DRAGONHAWK_EGG)
+            if ((SD3_SpellId(pSpell) != SPELL_HATCH_EGG_1 && SD3_SpellId(pSpell) != SPELL_HATCH_EGG_2) || pTarget->GetEntry() != NPC_DRAGONHAWK_EGG)
             {
                 return;
             }

--- a/scripts/eastern_kingdoms/zulaman/boss_malacrass.cpp
+++ b/scripts/eastern_kingdoms/zulaman/boss_malacrass.cpp
@@ -352,7 +352,7 @@ struct boss_malacrass : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Set the player's class when hit with soul siphon
-            if (pTarget->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_SIPHON_SOUL)
+            if (pTarget->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_SIPHON_SOUL)
             {
                 m_uiPlayerClass = ((Player*)pTarget)->getClass();
                 m_bCanUsePlayerSpell = true;

--- a/scripts/eastern_kingdoms/zulaman/boss_zuljin.cpp
+++ b/scripts/eastern_kingdoms/zulaman/boss_zuljin.cpp
@@ -307,7 +307,7 @@ struct boss_zuljin : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_SPIRIT_DRAIN)
+            if (SD3_SpellId(pSpell) == SPELL_SPIRIT_DRAIN)
             {
                 DoCastSpellIfCan(m_creature, aZuljinPhases[m_uiPhase].uiSpiritSpellId, CAST_INTERRUPT_PREVIOUS);
                 DoScriptText(aZuljinPhases[m_uiPhase].iYellId, m_creature);
@@ -338,7 +338,7 @@ struct boss_zuljin : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, SpellEntry const* pSpellEntry) override
         {
-            if (pSpellEntry->Id == SPELL_CLAW_RAGE && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpellEntry) == SPELL_CLAW_RAGE && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 DoCastSpellIfCan(m_creature, SPELL_CLAW_RAGE_TRIGGER, CAST_TRIGGERED);
                 m_uiLynxRushTimer += 8000;
@@ -573,7 +573,7 @@ struct npc_feather_vortex : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, SpellEntry const* pSpellEntry) override
         {
-            if (pSpellEntry->Id == SPELL_CYCLONE && pTarget->GetTypeId() == TYPEID_PLAYER && m_pInstance)
+            if (SD3_SpellId(pSpellEntry) == SPELL_CYCLONE && pTarget->GetTypeId() == TYPEID_PLAYER && m_pInstance)
             {
                 if (Creature* pZuljin = m_pInstance->GetSingleCreatureFromStorage(NPC_ZULJIN))
                 {

--- a/scripts/eastern_kingdoms/zulaman/zulaman.cpp
+++ b/scripts/eastern_kingdoms/zulaman/zulaman.cpp
@@ -118,7 +118,7 @@ struct npc_forest_frog : public CreatureScript
 
         void SpellHit(Unit* caster, const SpellEntry* spell) override
         {
-            if (spell->Id == SPELL_REMOVE_AMANI_CURSE && caster->GetTypeId() == TYPEID_PLAYER && m_creature->GetEntry() == NPC_FOREST_FROG)
+            if (SD3_SpellId(spell) == SPELL_REMOVE_AMANI_CURSE && caster->GetTypeId() == TYPEID_PLAYER && m_creature->GetEntry() == NPC_FOREST_FROG)
             {
                 // increase or decrease chance of mojo?
                 if (!urand(0, 49))

--- a/scripts/kalimdor/azuremyst_isle.cpp
+++ b/scripts/kalimdor/azuremyst_isle.cpp
@@ -122,7 +122,7 @@ struct npc_draenei_survivor : public CreatureScript
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
 #if defined (CLASSIC) || defined (TBC)
-            if (pSpell->Id == 28880)
+            if (SD3_SpellId(pSpell) == 28880)
 #endif
 #if defined (WOTLK) || defined (CATA) || defined(MISTS)
             if (pSpell->IsFitToFamilyMask(UI64LIT(0x0000000000000000), 0x080000000))

--- a/scripts/kalimdor/dustwallow_marsh.cpp
+++ b/scripts/kalimdor/dustwallow_marsh.cpp
@@ -1115,7 +1115,7 @@ struct boss_tethyr : public CreatureScript
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
             // spout on cannon
-            if (pCaster->GetEntry() == NPC_THERAMORE_CANNON && pSpell->Id == SPELL_CANNON_BLAST_DMG)
+            if (pCaster->GetEntry() == NPC_THERAMORE_CANNON && SD3_SpellId(pSpell) == SPELL_CANNON_BLAST_DMG)
             {
                 if (m_uiPhase == PHASE_SPOUT)
                 {

--- a/scripts/kalimdor/mulgore.cpp
+++ b/scripts/kalimdor/mulgore.cpp
@@ -88,7 +88,7 @@ struct npc_kyle_the_frenzied : public CreatureScript
 
         void SpellHit(Unit* pCaster, SpellEntry const* pSpell) override
         {
-            if (!m_creature->getVictim() && !m_bEvent && pSpell->Id == SPELL_LUNCH)
+            if (!m_creature->getVictim() && !m_bEvent && SD3_SpellId(pSpell) == SPELL_LUNCH)
             {
                 if (pCaster->GetTypeId() == TYPEID_PLAYER)
                 {

--- a/scripts/outland/auchindoun/auchenai_crypts/boss_exarch_maladaar.cpp
+++ b/scripts/outland/auchindoun/auchenai_crypts/boss_exarch_maladaar.cpp
@@ -269,7 +269,7 @@ struct boss_exarch_maladaar : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_STOLEN_SOUL && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_STOLEN_SOUL && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 DoSpawnCreature(NPC_STOLEN_SOUL, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSPAWN_TIMED_OOC_DESPAWN, 10000);
             }

--- a/scripts/outland/black_temple/boss_illidan.cpp
+++ b/scripts/outland/black_temple/boss_illidan.cpp
@@ -1539,7 +1539,7 @@ struct boss_maiev : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_CAGE_TRAP)
+            if (SD3_SpellId(pSpell) == SPELL_CAGE_TRAP)
             {
                 // Yell only the first time
                 if (!m_bHasYelledTrap)

--- a/scripts/outland/black_temple/boss_warlord_najentus.cpp
+++ b/scripts/outland/black_temple/boss_warlord_najentus.cpp
@@ -116,7 +116,7 @@ struct boss_najentus : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            if (m_bIsShielded && pSpell->Id == SPELL_HURL_SPINE)
+            if (m_bIsShielded && SD3_SpellId(pSpell) == SPELL_HURL_SPINE)
             {
                 if (m_creature->HasAura(SPELL_TIDAL_SHIELD))
                 {

--- a/scripts/outland/blades_edge_mountains.cpp
+++ b/scripts/outland/blades_edge_mountains.cpp
@@ -122,7 +122,7 @@ struct mobs_nether_drake : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_T_PHASE_MODULATOR && pCaster->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_T_PHASE_MODULATOR && pCaster->GetTypeId() == TYPEID_PLAYER)
             {
                 // we are nihil, so say before transform
                 if (m_creature->GetEntry() == NPC_NIHIL)

--- a/scripts/outland/coilfang_reservoir/serpent_shrine/boss_fathomlord_karathress.cpp
+++ b/scripts/outland/coilfang_reservoir/serpent_shrine/boss_fathomlord_karathress.cpp
@@ -122,7 +122,7 @@ struct boss_fathomlord_karathress : public CreatureScript
 
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
-            switch (pSpell->Id)
+            switch (SD3_SpellId(pSpell))
             {
                 case SPELL_POWER_OF_SHARKKIS:
                     DoScriptText(SAY_GAIN_ABILITY1, m_creature);

--- a/scripts/outland/coilfang_reservoir/serpent_shrine/boss_hydross_the_unstable.cpp
+++ b/scripts/outland/coilfang_reservoir/serpent_shrine/boss_hydross_the_unstable.cpp
@@ -197,7 +197,7 @@ struct boss_hydross_the_unstable : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Purify elementals and make them go to exit
-            if (pSpell->Id == SPELL_PURIFY_ELEMENTAL)
+            if (SD3_SpellId(pSpell) == SPELL_PURIFY_ELEMENTAL)
             {
                 ((Creature*)pTarget)->UpdateEntry(NPC_PURIFIED_ELEMENTAL);
                 pTarget->GetMotionMaster()->MovePoint(POINT_ID_ELEMENTAL_EXIT, aElementalExitPoint[0], aElementalExitPoint[1], aElementalExitPoint[2]);

--- a/scripts/outland/coilfang_reservoir/serpent_shrine/boss_morogrim_tidewalker.cpp
+++ b/scripts/outland/coilfang_reservoir/serpent_shrine/boss_morogrim_tidewalker.cpp
@@ -173,7 +173,7 @@ struct boss_morogrim_tidewalker : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Handle watery grave teleport - each player hit has his own teleport spell
-            if (pSpell->Id == SPELL_WATERY_GRAVE && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_WATERY_GRAVE && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 DoCastSpellIfCan(pTarget, m_auiSpellWateryGraveTeleport[m_uiGraveIndex], CAST_TRIGGERED);
                 ++m_uiGraveIndex;

--- a/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
+++ b/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
@@ -156,7 +156,7 @@ struct boss_ahune : public CreatureScript
 
         void SpellHit(Unit* /*pSource*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_SUBMERGE)
+            if (SD3_SpellId(pSpell) == SPELL_SUBMERGE)
             {
                 // Note: the following spell breaks the visual. Needs to be fixed!
                 // DoCastSpellIfCan(m_creature, SPELL_AHUNE_SELF_STUN, CAST_TRIGGERED);

--- a/scripts/outland/gruuls_lair/boss_gruul.cpp
+++ b/scripts/outland/gruuls_lair/boss_gruul.cpp
@@ -137,7 +137,7 @@ struct boss_gruul : public CreatureScript
         {
             // This to emulate effect1 (77) of SPELL_GROUND_SLAM, knock back to any direction
             // It's initially wrong, since this will cause fall damage, which is by comments, not intended.
-            if (pSpell->Id == SPELL_GROUND_SLAM)
+            if (SD3_SpellId(pSpell) == SPELL_GROUND_SLAM)
             {
                 if (pTarget->GetTypeId() == TYPEID_PLAYER)
                 {
@@ -150,7 +150,7 @@ struct boss_gruul : public CreatureScript
             }
 
             // this part should be in mangos
-            if (pSpell->Id == SPELL_SHATTER)
+            if (SD3_SpellId(pSpell) == SPELL_SHATTER)
             {
                 // this spell must have custom handling in mangos, dealing damage based on distance
                 pTarget->CastSpell(pTarget, SPELL_SHATTER_EFFECT, true);

--- a/scripts/outland/gruuls_lair/boss_high_king_maulgar.cpp
+++ b/scripts/outland/gruuls_lair/boss_high_king_maulgar.cpp
@@ -383,7 +383,7 @@ struct boss_kiggler_the_crazed : public CreatureScript
         {
             // Spell currently not supported by core. Knock back effect should lower threat
             // Workaround in script:
-            if (pSpell->Id == SPELL_ARCANE_EXPLOSION)
+            if (SD3_SpellId(pSpell) == SPELL_ARCANE_EXPLOSION)
             {
                 if (pVictim->GetTypeId() != TYPEID_PLAYER)
                 {

--- a/scripts/outland/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
+++ b/scripts/outland/hellfire_citadel/magtheridons_lair/boss_magtheridon.cpp
@@ -171,7 +171,7 @@ struct boss_magtheridon : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
             // When banished by the cubes
-            if (pSpell->Id == SPELL_SHADOW_CAGE)
+            if (SD3_SpellId(pSpell) == SPELL_SHADOW_CAGE)
             {
                 DoScriptText(SAY_BANISH, m_creature);
             }
@@ -587,7 +587,7 @@ struct npc_target_trigger : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
             // Workaround for missing core support for this type of dummy aura
-            if (pSpell->Id == SPELL_QUAKE_EFFECT)
+            if (SD3_SpellId(pSpell) == SPELL_QUAKE_EFFECT)
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_DEBRIS_VISUAL) == CAST_OK)
                 {

--- a/scripts/outland/hellfire_peninsula.cpp
+++ b/scripts/outland/hellfire_peninsula.cpp
@@ -309,7 +309,7 @@ struct npc_demoniac_scryer : public CreatureScript
 
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
-            if (pTarget->GetEntry() == NPC_HELLFIRE_WARDLING && pSpell->Id == SPELL_SUCKER_DESPAWN_MOB)
+            if (pTarget->GetEntry() == NPC_HELLFIRE_WARDLING && SD3_SpellId(pSpell) == SPELL_SUCKER_DESPAWN_MOB)
             {
                 ((Creature*)pTarget)->ForcedDespawn();
             }

--- a/scripts/outland/nagrand.cpp
+++ b/scripts/outland/nagrand.cpp
@@ -326,7 +326,7 @@ struct npc_nagrand_captive : public CreatureScript
 
         void SpellHitTarget(Unit* /*pTarget*/, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_CHAIN_LIGHTNING)
+            if (SD3_SpellId(pSpell) == SPELL_CHAIN_LIGHTNING)
             {
                 if (urand(0, 9))
                 {

--- a/scripts/outland/shadowmoon_valley.cpp
+++ b/scripts/outland/shadowmoon_valley.cpp
@@ -98,7 +98,7 @@ struct mob_mature_netherwing_drake : public CreatureScript
                 return;
             }
 
-            if (pCaster->GetTypeId() == TYPEID_PLAYER && pSpell->Id == SPELL_PLACE_CARCASS && !m_creature->HasAura(SPELL_JUST_EATEN))
+            if (pCaster->GetTypeId() == TYPEID_PLAYER && SD3_SpellId(pSpell) == SPELL_PLACE_CARCASS && !m_creature->HasAura(SPELL_JUST_EATEN))
             {
                 m_playerGuid = pCaster->GetObjectGuid();
                 m_uiEatTimer = 5000;
@@ -234,7 +234,7 @@ struct mob_enslaved_netherwing_drake : public CreatureScript
 
         void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
         {
-            if (pSpell->Id == SPELL_HIT_FORCE_OF_NELTHARAKU && !m_uiFlyTimer)
+            if (SD3_SpellId(pSpell) == SPELL_HIT_FORCE_OF_NELTHARAKU && !m_uiFlyTimer)
             {
                 if (Player* pPlayer = pCaster->GetCharmerOrOwnerPlayerOrPlayerItself())
                 {

--- a/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -328,7 +328,7 @@ struct boss_kaelthas : public CreatureScript
         void SpellHit(Unit* /*pCaster*/, const SpellEntry* pSpell) override
         {
             // Handle summon weapons event
-            if (pSpell->Id == SPELL_SUMMON_WEAPONS)
+            if (SD3_SpellId(pSpell) == SPELL_SUMMON_WEAPONS)
             {
                 for (uint8 i = 0; i < MAX_WEAPONS; ++i)
                 {
@@ -343,7 +343,7 @@ struct boss_kaelthas : public CreatureScript
         void SpellHitTarget(Unit* pTarget, const SpellEntry* pSpell) override
         {
             // Handle gravity lapse teleport - each player hit has his own teleport spell
-            if (pSpell->Id == SPELL_GRAVITY_LAPSE && pTarget->GetTypeId() == TYPEID_PLAYER)
+            if (SD3_SpellId(pSpell) == SPELL_GRAVITY_LAPSE && pTarget->GetTypeId() == TYPEID_PLAYER)
             {
                 DoCastSpellIfCan(pTarget, m_auiSpellGravityLapseTeleport[m_uiGravityIndex], CAST_TRIGGERED);
                 pTarget->CastSpell(pTarget, SPELL_GRAVITY_LAPSE_KNOCKBACK, true, nullptr, nullptr, m_creature->GetObjectGuid());
@@ -898,7 +898,7 @@ struct advisor_base_ai : public ScriptedAI
     void SpellHit(Unit* pCaster, const SpellEntry* pSpell) override
     {
         // Remove fake death
-        if (pSpell->Id == SPELL_RESURRECTION && pCaster->GetEntry() == NPC_KAELTHAS)
+        if (SD3_SpellId(pSpell) == SPELL_RESURRECTION && pCaster->GetEntry() == NPC_KAELTHAS)
         {
             m_creature->SetStandState(UNIT_STAND_STATE_STAND);
             m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);

--- a/scripts/world/npcs_special.cpp
+++ b/scripts/world/npcs_special.cpp
@@ -1248,7 +1248,10 @@ struct npc_innkeeper : public CreatureScript
         // Should only apply to innkeeper close to start areas.
         if (AreaTableEntry const* pAreaEntry = GetAreaEntryByAreaID(pCreature->GetAreaId()))
         {
-#if defined (TBC) || defined (WOTLK) || defined (CATA) || defined(MISTS)
+#if defined (TBC)
+            // Note: this area flag doesn't exist in 1.12.1. The behavior of this gossip require additional research
+            if (pAreaEntry->Flags & AREA_FLAG_LOWLEVEL)
+#elif defined (WOTLK) || defined (CATA) || defined(MISTS)
             // Note: this area flag doesn't exist in 1.12.1. The behavior of this gossip require additional research
             if (pAreaEntry->flags & AREA_FLAG_LOWLEVEL)
 #endif


### PR DESCRIPTION
mangos-one (WoW TBC 2.4.3.8606) is aligning its DBC structs to build-exact `.dbd` names (a faithful port of the mangos-zero #428 playbook to TBC). SD3 is a shared submodule compiled by every mangos fork, so these are **purely additive** cross-fork guards — every existing CLASSIC / WOTLK / CATA / MISTS branch is byte-for-byte unchanged; only a new TBC arm is added. mangos-one builds green and boots clean (all DBC stores load, live druid spell/aura smoke passed); no other fork's compiled paths are touched.

Three commits:

1. **SpellRange** (`sc_creature.h`) — add `#elif defined(TBC)` to `SD3_SpellRangeMin/Max`. TBC returns the build-exact `RangeMin/RangeMax` (same as CLASSIC, which zero already aligned); WOTLK/CATA keep `minRange/maxRange`.
2. **AreaTable.flags** (`npcs_special.cpp`) — split the existing `TBC||WOTLK||CATA||MISTS` gossip guard so TBC reads the aligned `Flags` while WOTLK/CATA/MISTS keep `flags`; CLASSIC is excluded from the block as before.
3. **Spell accessors + Spell.Id routing** —
   - `sc_creature.h`: add `#elif defined(TBC)` to six `SD3_Spell*` accessors (`SpellId`, `ManaCost`, `PowerType`, `RangeIndex`, `EffectImplicitTargetA`, `EffectApplyAuraName`); TBC returns the build-exact name (converging with CLASSIC), other forks unchanged.
   - **42 raw `pSpell->Id` sites across 33 TBC-content boss scripts** (Karazhan / Sunwell / Black Temple / Zul'Aman / Outland / …) replaced with the existing `SD3_SpellId(pSpell)` accessor. These are TBC-and-later content that mangos-zero never compiles, so #428 never needed to route them; the accessor is equivalent on every fork (returns `->ID` for CLASSIC/TBC, `->Id` for WOTLK+), matching the established SD3 pattern already used in 23 other script files.

No behavior change on any existing fork; TBC now compiles against a build-exact `SpellEntry`/`AreaTableEntry`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/98)
<!-- Reviewable:end -->
