### PR TITLE
MISTS: guard arms for MoP (Four) DBC field renames

### DIFF
--- a/include/sc_creature.h
+++ b/include/sc_creature.h
@@ -48,6 +48,8 @@ inline uint32 SD3_SpellId(SpellEntry const* pSpell)
     return pSpell->ID;
 #elif defined (WOTLK)
     return pSpell->ID;
+#elif defined (MISTS)
+    return pSpell->ID;
 #else
     return pSpell->Id;
 #endif
@@ -154,6 +156,8 @@ inline uint32 SD3_AreaTriggerId(AreaTriggerEntry const* pAt)
     return pAt->ID;
 #elif defined (WOTLK)
     return pAt->ID;
+#elif defined (MISTS)
+    return pAt->ID;
 #else
     return pAt->id;
 #endif
@@ -219,6 +223,8 @@ inline float SD3_SpellRangeMax(SpellRangeEntry const* pRange)
 inline uint32 SD3_FactionTemplateFaction(FactionTemplateEntry const* pFT)
 {
 #if defined (WOTLK) || defined (CLASSIC)
+    return pFT->Faction;
+#elif defined (MISTS)
     return pFT->Faction;
 #else
     return pFT->faction;

--- a/scripts/world/npcs_special.cpp
+++ b/scripts/world/npcs_special.cpp
@@ -1251,7 +1251,10 @@ struct npc_innkeeper : public CreatureScript
 #if defined (TBC) || defined (WOTLK)
             // Note: this area flag doesn't exist in 1.12.1. The behavior of this gossip require additional research
             if (pAreaEntry->Flags & AREA_FLAG_LOWLEVEL)
-#elif defined (CATA) || defined(MISTS)
+#elif defined (MISTS)
+            // Note: this area flag doesn't exist in 1.12.1. The behavior of this gossip require additional research
+            if (pAreaEntry->Flags & AREA_FLAG_LOWLEVEL)
+#elif defined (CATA)
             // Note: this area flag doesn't exist in 1.12.1. The behavior of this gossip require additional research
             if (pAreaEntry->flags & AREA_FLAG_LOWLEVEL)
 #endif


### PR DESCRIPTION
## Summary

Adds `MISTS` expansion arms to the shared SD3 accessor shims (and one script) so the **Four (MoP 5.4.8)** server can align its core DBC struct fields to the build-exact client names without breaking the other forks. Purely **additive**: every existing `CLASSIC` / `TBC` / `WOTLK` arm and every `#else` (CATA) path is byte-for-byte unchanged, so Zero / One / Two / Three compile identically — only the new `#elif defined(MISTS)` arms are added.

MoP renamed several DBC fields that SD3 reads; the MISTS arm returns the new client-exact name, while the pre-existing arms keep the legacy names for the forks that still use them.

## What changed (`include/sc_creature.h` accessor shims + one script)

- `SD3_SpellId` — MISTS arm returns `pSpell->ID` (was `Id`).
- `SD3_AreaTriggerId` — MISTS arm returns `pAt->ID` (was `id`). The `X/Y/Z` shims are untouched (those columns are unchanged in MoP).
- `SD3_FactionTemplateFaction` — MISTS arm returns `pFT->Faction` (was `faction`).
- `scripts/world/npcs_special.cpp` — the `AreaTable.flags` read in the explicit `#elif defined(CATA) || defined(MISTS)` arm is split so MISTS reads `->Flags` and CATA keeps `->flags`.

## Cross-fork safety

Every hunk is either a new `#elif defined(MISTS)` insertion or a `CATA||MISTS` → `MISTS` / `CATA` split where the CATA half is byte-identical to before. No `CLASSIC`/`TBC`/`WOTLK`/`CATA` behavior changes. Verified by a raw (autocrlf-off) diff audit against the base and an adversarial cross-fork review.

## Land order

Companion to the Four core PR and the Eluna MISTS PR. Merge **this + Eluna first**, then the core PR re-points its submodule pointers to the merged masters. Base pin for this branch: current SD3 master (`fb3430a8`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/ScriptDev3/100)
<!-- Reviewable:end -->
